### PR TITLE
[BUGFIX] Fix error from video IDs starting with a dash

### DIFF
--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -11,19 +11,21 @@ defmodule Pinchflat.Media.MediaItem do
   alias Pinchflat.Media.MediaMetadata
   alias Pinchflat.Media.MediaItemSearchIndex
 
-  @allowed_fields ~w(
-    title
-    media_id
-    description
-    original_url
-    livestream
-    media_downloaded_at
-    media_filepath
-    subtitle_filepaths
-    thumbnail_filepath
-    metadata_filepath
-    source_id
-  )a
+  @allowed_fields [
+    # these fields are captured on indexing
+    :title,
+    :media_id,
+    :description,
+    :original_url,
+    :livestream,
+    :source_id,
+    # these fields are captured on download
+    :media_downloaded_at,
+    :media_filepath,
+    :subtitle_filepaths,
+    :thumbnail_filepath,
+    :metadata_filepath
+  ]
   @required_fields ~w(title original_url livestream media_id source_id)a
 
   schema "media_items" do

--- a/lib/pinchflat/media_client/video_downloader.ex
+++ b/lib/pinchflat/media_client/video_downloader.ex
@@ -32,7 +32,7 @@ defmodule Pinchflat.MediaClient.VideoDownloader do
     item_with_preloads = Repo.preload(media_item, [:metadata, source: :media_profile])
     media_profile = item_with_preloads.source.media_profile
 
-    case download_for_media_profile(media_item.media_id, media_profile, backend) do
+    case download_for_media_profile(media_item.original_url, media_profile, backend) do
       {:ok, parsed_json} ->
         parser = metadata_parser(backend)
 

--- a/test/pinchflat/media_client/video_downloader_test.exs
+++ b/test/pinchflat/media_client/video_downloader_test.exs
@@ -19,7 +19,8 @@ defmodule Pinchflat.MediaClient.VideoDownloaderTest do
 
   describe "download_for_media_item/3" do
     test "it calls the backend runner", %{media_item: media_item} do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, ot ->
+      expect(YtDlpRunnerMock, :run, fn url, _opts, ot ->
+        assert url == media_item.original_url
         assert ot == "after_move:%()j"
 
         {:ok, render_metadata(:media_metadata)}

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -10,12 +10,14 @@ defmodule Pinchflat.MediaFixtures do
   Generate a media_item.
   """
   def media_item_fixture(attrs \\ %{}) do
+    media_id = Faker.String.base64(12)
+
     {:ok, media_item} =
       attrs
       |> Enum.into(%{
-        media_id: Faker.String.base64(12),
+        media_id: media_id,
         title: Faker.Commerce.product_name(),
-        original_url: "https://www.youtube.com/channel/#{Faker.String.base64(12)}",
+        original_url: "https://www.youtube.com/watch?v=#{media_id}",
         livestream: false,
         media_filepath: "/video/#{Faker.File.file_name(:video)}",
         source_id: SourcesFixtures.source_fixture().id


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Improved MediaItem module docs a little by highlighting which attributes come from which lifecycle events

## What's fixed?

- Fixes an error from the yt-dlp runner when a video who's ID starts with a `-` was downloaded. In this case it was interpreted as a CLI argument and an error is thrown. The fix is to pass the full `original_url`

## Any other comments?

N/A
