### PR TITLE
[BUGFIX] resolve windows filename bug

### DIFF
--- a/lib/pinchflat/profiles/options/yt_dlp/download_option_builder.ex
+++ b/lib/pinchflat/profiles/options/yt_dlp/download_option_builder.ex
@@ -34,7 +34,7 @@ defmodule Pinchflat.Profiles.Options.YtDlp.DownloadOptionBuilder do
 
   # This will be updated a lot as I add new options to profiles
   defp default_options do
-    [:no_progress]
+    [:no_progress, :windows_filenames]
   end
 
   defp subtitle_options(media_profile) do

--- a/test/pinchflat/profiles/options/yt_dlp/download_option_builder_test.exs
+++ b/test/pinchflat/profiles/options/yt_dlp/download_option_builder_test.exs
@@ -16,6 +16,15 @@ defmodule Pinchflat.Profiles.Options.YtDlp.DownloadOptionBuilderTest do
     end
   end
 
+  describe "build/1 when testing default options" do
+    test "it includes default options" do
+      assert {:ok, res} = DownloadOptionBuilder.build(@media_profile)
+
+      assert :no_progress in res
+      assert :windows_filenames in res
+    end
+  end
+
   describe "build/1 when testing subtitle options" do
     test "includes :write_subs option when specified" do
       media_profile = %MediaProfile{@media_profile | download_subs: true}


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Resolves a bug where media could be attempted to be downloaded to an invalid filepath. 
  - This normally isn't an issue with `yt-dlp` since it automatically sets this based on your OS - BUT - this comes into effect when the storage is accessed on a different device than the app which is the intended operating mode. For example, the Unraid share I was using had SMB enabled and directories ending with `.` would get mangled, leading to the actual path on-disk not matching what the app _thinks_ the path is

## Any other comments?

N/A
