### PR TITLE
Streaming media item creation during indexing

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -15,6 +15,8 @@ alias Pinchflat.Sources
 alias Pinchflat.MediaClient.{SourceDetails, VideoDownloader}
 alias Pinchflat.Metadata.{Zipper, ThumbnailFetcher}
 
+alias Pinchflat.Utils.FilesystemUtils.FileFollowerServer
+
 defmodule IexHelpers do
   def playlist_url do
     "https://www.youtube.com/playlist?list=PLmqC3wPkeL8kSlTCcSMDD63gmSi7evcXS"

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,7 +20,8 @@ config :pinchflat,
   # Setting AUTH_USERNAME and AUTH_PASSWORD implies you want to use basic auth.
   # If either is unset, basic auth will not be used.
   basic_auth_username: System.get_env("AUTH_USERNAME"),
-  basic_auth_password: System.get_env("AUTH_PASSWORD")
+  basic_auth_password: System.get_env("AUTH_PASSWORD"),
+  file_watcher_poll_interval: 1000
 
 # Configures the endpoint
 config :pinchflat, PinchflatWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,8 @@ config :pinchflat,
   yt_dlp_executable: Path.join([File.cwd!(), "/test/support/scripts/yt-dlp-mocks/repeater.sh"]),
   media_directory: Path.join([System.tmp_dir!(), "test", "videos"]),
   metadata_directory: Path.join([System.tmp_dir!(), "test", "metadata"]),
-  tmpfile_directory: Path.join([System.tmp_dir!(), "test", "tmpfiles"])
+  tmpfile_directory: Path.join([System.tmp_dir!(), "test", "tmpfiles"]),
+  file_watcher_poll_interval: 50
 
 config :pinchflat, Oban, testing: :manual
 

--- a/lib/pinchflat/media.ex
+++ b/lib/pinchflat/media.ex
@@ -67,6 +67,24 @@ defmodule Pinchflat.Media do
   end
 
   @doc """
+  For a given media_item, tells you if it is pending download. This is defined as
+  the media_item having a `media_filepath` of `nil` and matching the format selection
+  rules of the parent media_profile.
+
+  Intentionally does not take the `download_media` setting of the source into account.
+
+  Returns boolean()
+  """
+  def pending_download?(%MediaItem{} = media_item) do
+    media_profile = Repo.preload(media_item, source: :media_profile).source.media_profile
+
+    MediaItem
+    |> where([mi], mi.id == ^media_item.id and is_nil(mi.media_filepath))
+    |> where(^build_format_clauses(media_profile))
+    |> Repo.exists?()
+  end
+
+  @doc """
   Returns a list of media_items that match the search term. Adds a `matching_search_term`
   virtual field to the result set.
 

--- a/lib/pinchflat/media_client/backends/backend_command_runner.ex
+++ b/lib/pinchflat/media_client/backends/backend_command_runner.ex
@@ -4,4 +4,5 @@ defmodule Pinchflat.MediaClient.Backends.BackendCommandRunner do
   """
 
   @callback run(binary(), keyword(), binary()) :: {:ok, binary()} | {:error, binary(), integer()}
+  @callback run(binary(), keyword(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
 end

--- a/lib/pinchflat/media_client/source_details.ex
+++ b/lib/pinchflat/media_client/source_details.ex
@@ -22,16 +22,21 @@ defmodule Pinchflat.MediaClient.SourceDetails do
   Returns a list of basic video data mapsfor the given source URL OR
   source record using the given backend.
 
+  Options:
+    - :file_listener_handler - a function that will be called with the path to the
+      file that will be written to by yt-dlp. This is useful for
+      setting up a file watcher to read the file as it gets written to.
+
   Returns {:ok, [map()]} | {:error, any, ...}.
   """
-  def get_media_attributes(sourceable, backend \\ :yt_dlp)
+  def get_media_attributes(sourceable, opts \\ [], backend \\ :yt_dlp)
 
-  def get_media_attributes(%Source{} = source, backend) do
-    source_module(backend).get_media_attributes(source.collection_id)
+  def get_media_attributes(%Source{} = source, opts, backend) do
+    get_media_attributes(source.collection_id, opts, backend)
   end
 
-  def get_media_attributes(source_url, backend) when is_binary(source_url) do
-    source_module(backend).get_media_attributes(source_url)
+  def get_media_attributes(source_url, opts, backend) when is_binary(source_url) do
+    source_module(backend).get_media_attributes(source_url, opts)
   end
 
   defp source_module(backend) do

--- a/lib/pinchflat/tasks.ex
+++ b/lib/pinchflat/tasks.ex
@@ -2,7 +2,6 @@ defmodule Pinchflat.Tasks do
   @moduledoc """
   The Tasks context.
   """
-
   import Ecto.Query, warn: false
   alias Pinchflat.Repo
 

--- a/lib/pinchflat/tasks/media_item_tasks.ex
+++ b/lib/pinchflat/tasks/media_item_tasks.ex
@@ -1,7 +1,9 @@
 defmodule Pinchflat.Tasks.MediaItemTasks do
   @moduledoc """
-  This module contains methods used by or used to control tasks (aka workers)
-  related to media items.
+  Contains methods used by OR used to create/manage tasks for media items.
+
+  Tasks/workers are meant to be thin wrappers so most of the actual work they
+  do is also defined here. Essentially, a one-stop-shop for media-related tasks/workers.
   """
   alias Pinchflat.Media
 

--- a/lib/pinchflat/utils/filesystem_utils.ex
+++ b/lib/pinchflat/utils/filesystem_utils.ex
@@ -1,0 +1,23 @@
+defmodule Pinchflat.Utils.FilesystemUtils do
+  @moduledoc """
+  Utility methods for working with the filesystem
+  """
+
+  alias Pinchflat.Utils.StringUtils
+
+  @doc """
+  Generates a temporary file and returns its path. The file is empty and has the given type.
+  Generates all the directories in the path if they don't exist.
+
+  Returns binary()
+  """
+  def generate_metadata_tmpfile(type) do
+    tmpfile_directory = Application.get_env(:pinchflat, :tmpfile_directory)
+    filepath = Path.join([tmpfile_directory, "#{StringUtils.random_string(64)}.#{type}"])
+
+    :ok = File.mkdir_p!(Path.dirname(filepath))
+    :ok = File.write(filepath, "")
+
+    filepath
+  end
+end

--- a/lib/pinchflat/utils/filesystem_utils/file_follower_server.ex
+++ b/lib/pinchflat/utils/filesystem_utils/file_follower_server.ex
@@ -1,0 +1,121 @@
+defmodule Pinchflat.Utils.FilesystemUtils.FileFollowerServer do
+  @moduledoc """
+  A GenServer that watches a file for new lines and processes them as they come in.
+  This is useful for tailing log files and other similar tasks. If there's no activity
+  for a certain amount of time, the server will stop itself.
+  """
+  use GenServer
+
+  require Logger
+
+  @poll_interval_ms Application.compile_env(:pinchflat, :file_watcher_poll_interval)
+  @activity_timeout_ms 10_000
+
+  # Client API
+  @doc """
+  Starts the file follower server
+
+  Returns {:ok, pid} or {:error, reason}
+  """
+  def start_link() do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  @doc """
+  Starts the file watcher for a given filepath and handler function.
+
+  Returns :ok
+  """
+  def watch_file(process, filepath, handler) do
+    GenServer.cast(process, {:watch_file, filepath, handler})
+  end
+
+  @doc """
+  Stops the file watcher and closes the file.
+
+  Returns :ok
+  """
+  def stop(process) do
+    GenServer.cast(process, :stop)
+  end
+
+  # Server Callbacks
+  @impl true
+  def init(_opts) do
+    # Start with a blank state because, based on the common calling
+    # pattern for this module, we'll need a reference to the server's
+    # PID before we start watching any files so we can later stop the
+    # server gracefully.
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_cast({:watch_file, filepath, handler}, _old_state) do
+    {:ok, io_device} = :file.open(filepath, [:raw, :read_ahead, :binary])
+
+    state = %{
+      io_device: io_device,
+      last_activity: DateTime.utc_now(),
+      handler: handler
+    }
+
+    Process.send(self(), :read_new_lines, [])
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(:stop, state) do
+    Logger.debug("Gracefully stopping file follower")
+    :file.close(state.io_device)
+
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_info(:read_new_lines, state) do
+    last_activity = state.last_activity
+
+    # If there's no new lines written for a certain amount of time, stop the server
+    if DateTime.diff(DateTime.utc_now(), last_activity, :millisecond) > @activity_timeout_ms do
+      Logger.debug("No activity for #{@activity_timeout_ms}ms. Requesting stop.")
+      stop(self())
+
+      {:noreply, state}
+    else
+      attempt_process_new_lines(state)
+    end
+  end
+
+  defp attempt_process_new_lines(state) do
+    io_device = state.io_device
+
+    # This reads one line at a time. If a line is found, it
+    # will be passed to the handler, we'll note the time of
+    # the last activity, and then we'll immediately call this
+    # again to read the next line.
+    #
+    # If there are no lines, it waits for the poll interval
+    # before trying again.
+    case :file.read_line(io_device) do
+      {:ok, line} ->
+        state.handler.(line)
+
+        Process.send(self(), :read_new_lines, [])
+
+        {:noreply, %{state | last_activity: DateTime.utc_now()}}
+
+      :eof ->
+        Logger.debug("EOF reached, waiting before trying to read new lines")
+        Process.send_after(self(), :read_new_lines, @poll_interval_ms)
+
+        {:noreply, state}
+
+      {:error, reason} ->
+        Logger.error("Error reading file: #{reason}")
+        stop(self())
+
+        {:noreply, state}
+    end
+  end
+end

--- a/lib/pinchflat/workers/media_indexing_worker.ex
+++ b/lib/pinchflat/workers/media_indexing_worker.ex
@@ -43,25 +43,20 @@ defmodule Pinchflat.Workers.MediaIndexingWorker do
     case {source.index_frequency_minutes, source.last_indexed_at} do
       {index_freq, _} when index_freq > 0 ->
         # If the indexing is on a schedule simply run indexing and reschedule
-        index_media(source)
+        SourceTasks.index_and_enqueue_download_for_media_items(source)
         reschedule_indexing(source)
 
       {_, nil} ->
         # If the source has never been indexed, index it once
         # even if it's not meant to reschedule
-        index_media(source)
+        SourceTasks.index_and_enqueue_download_for_media_items(source)
+        :ok
 
       _ ->
         # If the source HAS been indexed and is not meant to reschedule,
         # perform a no-op
         :ok
     end
-  end
-
-  defp index_media(source) do
-    SourceTasks.index_media_items(source)
-    # This method handles the case where a source is set to not download media
-    SourceTasks.enqueue_pending_media_tasks(source)
   end
 
   defp reschedule_indexing(source) do

--- a/test/pinchflat/media_client/backends/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/media_client/backends/yt_dlp/command_runner_test.exs
@@ -10,7 +10,7 @@ defmodule Pinchflat.MediaClient.Backends.YtDlp.CommandRunnerTest do
     on_exit(&reset_executable/0)
   end
 
-  describe "run/2" do
+  describe "run/4" do
     test "it returns the output and status when the command succeeds" do
       assert {:ok, _output} = Runner.run(@video_url, [], "")
     end
@@ -56,6 +56,12 @@ defmodule Pinchflat.MediaClient.Backends.YtDlp.CommandRunnerTest do
       wrap_executable("/bin/false", fn ->
         assert {:error, "", 1} = Runner.run(@video_url, [], "")
       end)
+    end
+
+    test "optionally lets you specify an output_filepath" do
+      assert {:ok, output} = Runner.run(@video_url, [], "%(id)s", output_filepath: "/tmp/yt-dlp-output.json")
+
+      assert String.contains?(output, "--print-to-file %(id)s /tmp/yt-dlp-output.json")
     end
   end
 

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -215,6 +215,34 @@ defmodule Pinchflat.MediaTest do
     end
   end
 
+  describe "pending_download?/1" do
+    test "returns true when the media hasn't been downloaded" do
+      media_item = media_item_fixture(%{media_filepath: nil})
+
+      assert Media.pending_download?(media_item)
+    end
+
+    test "returns false if the media has been downloaded" do
+      media_item = media_item_fixture(%{media_filepath: "/video/#{Faker.File.file_name(:video)}"})
+
+      refute Media.pending_download?(media_item)
+    end
+
+    test "returns false if the media hasn't been downloaded but the profile doesn't DL shorts" do
+      source = source_fixture(%{media_profile_id: media_profile_fixture(%{shorts_behaviour: :exclude}).id})
+      media_item = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+
+      refute Media.pending_download?(media_item)
+    end
+
+    test "returns false if the media hasn't been downloaded but the profile doesn't DL livestreams" do
+      source = source_fixture(%{media_profile_id: media_profile_fixture(%{livestream_behaviour: :exclude}).id})
+      media_item = media_item_fixture(%{source_id: source.id, media_filepath: nil, livestream: true})
+
+      refute Media.pending_download?(media_item)
+    end
+  end
+
   describe "search/1" do
     setup do
       media_item =

--- a/test/pinchflat/tasks/source_tasks_test.exs
+++ b/test/pinchflat/tasks/source_tasks_test.exs
@@ -5,6 +5,7 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
   import Pinchflat.TasksFixtures
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
+  import Pinchflat.ProfilesFixtures
 
   alias Pinchflat.Tasks
   alias Pinchflat.Tasks.Task
@@ -43,7 +44,7 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     end
   end
 
-  describe "index_media_items/1" do
+  describe "index_and_enqueue_download_for_media_items/1" do
     setup do
       stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
@@ -53,7 +54,7 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     end
 
     test "it creates a media_item record for each media ID returned", %{source: source} do
-      assert media_items = SourceTasks.index_media_items(source)
+      assert media_items = SourceTasks.index_and_enqueue_download_for_media_items(source)
 
       assert Enum.count(media_items) == 3
       assert ["video1", "video2", "video3"] == Enum.map(media_items, & &1.media_id)
@@ -65,15 +66,15 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
 
     test "it attaches all media_items to the given source", %{source: source} do
       source_id = source.id
-      assert media_items = SourceTasks.index_media_items(source)
+      assert media_items = SourceTasks.index_and_enqueue_download_for_media_items(source)
 
       assert Enum.count(media_items) == 3
       assert Enum.all?(media_items, fn %MediaItem{source_id: ^source_id} -> true end)
     end
 
     test "it won't duplicate media_items based on media_id and source", %{source: source} do
-      _first_run = SourceTasks.index_media_items(source)
-      _duplicate_run = SourceTasks.index_media_items(source)
+      _first_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
+      _duplicate_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
 
       media_items = Repo.preload(source, :media_items).media_items
       assert Enum.count(media_items) == 3
@@ -82,8 +83,8 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     test "it can duplicate media_ids for different sources", %{source: source} do
       other_source = source_fixture()
 
-      media_items = SourceTasks.index_media_items(source)
-      media_items_other_source = SourceTasks.index_media_items(other_source)
+      media_items = SourceTasks.index_and_enqueue_download_for_media_items(source)
+      media_items_other_source = SourceTasks.index_and_enqueue_download_for_media_items(other_source)
 
       assert Enum.count(media_items) == 3
       assert Enum.count(media_items_other_source) == 3
@@ -93,8 +94,8 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     end
 
     test "it returns a list of media_items or changesets", %{source: source} do
-      first_run = SourceTasks.index_media_items(source)
-      duplicate_run = SourceTasks.index_media_items(source)
+      first_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
+      duplicate_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
 
       assert Enum.all?(first_run, fn %MediaItem{} -> true end)
       assert Enum.all?(duplicate_run, fn %Ecto.Changeset{} -> true end)
@@ -103,19 +104,37 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     test "it updates the source's last_indexed_at field", %{source: source} do
       assert source.last_indexed_at == nil
 
-      SourceTasks.index_media_items(source)
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
       source = Repo.reload!(source)
 
       assert DateTime.diff(DateTime.utc_now(), source.last_indexed_at) < 2
     end
+
+    test "it enqueues a job for each pending media item" do
+      source = source_fixture()
+      media_item = media_item_fixture(source_id: source.id, media_filepath: nil)
+
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
+
+      assert_enqueued(worker: VideoDownloadWorker, args: %{"id" => media_item.id})
+    end
+
+    test "it does not attach tasks if the source is set to not download" do
+      source = source_fixture(download_media: false)
+      media_item = media_item_fixture(source_id: source.id, media_filepath: nil)
+
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
+
+      assert [] = Tasks.list_tasks_for(:media_item_id, media_item.id)
+    end
   end
 
-  describe "index_media_items/1 when testing file watcher" do
+  describe "index_and_enqueue_download_for_media_items/1 when testing file watcher" do
     setup do
       {:ok, [source: source_fixture()]}
     end
 
-    test "it creates a new media item for everything already in the file", %{source: source} do
+    test "creates a new media item for everything already in the file", %{source: source} do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
 
       stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
@@ -124,13 +143,82 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
 
         # Need to add a delay to ensure the file watcher has time to read the file
         :timer.sleep(watcher_poll_interval * 2)
-
+        # We know we're testing the file watcher since the syncronous call will only
+        # return an empty string (creating no records)
         {:ok, ""}
       end)
 
       assert Repo.aggregate(MediaItem, :count, :id) == 0
-      SourceTasks.index_media_items(source)
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
       assert Repo.aggregate(MediaItem, :count, :id) == 3
+    end
+
+    test "enqueues a download for everything already in the file", %{source: source} do
+      watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
+
+      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+        filepath = Keyword.get(addl_opts, :output_filepath)
+        File.write(filepath, source_attributes_return_fixture())
+
+        # Need to add a delay to ensure the file watcher has time to read the file
+        :timer.sleep(watcher_poll_interval * 2)
+        # We know we're testing the file watcher since the syncronous call will only
+        # return an empty string (creating no records)
+        {:ok, ""}
+      end)
+
+      refute_enqueued(worker: VideoDownloadWorker)
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
+      assert_enqueued(worker: VideoDownloadWorker)
+    end
+
+    test "does not enqueue downloads if the source is set to not download" do
+      watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
+      source = source_fixture(download_media: false)
+
+      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+        filepath = Keyword.get(addl_opts, :output_filepath)
+        File.write(filepath, source_attributes_return_fixture())
+
+        # Need to add a delay to ensure the file watcher has time to read the file
+        :timer.sleep(watcher_poll_interval * 2)
+        # We know we're testing the file watcher since the syncronous call will only
+        # return an empty string (creating no records)
+        {:ok, ""}
+      end)
+
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
+      refute_enqueued(worker: VideoDownloadWorker)
+    end
+
+    test "does not enqueue downloads for media that doesn't match the profile's format options" do
+      watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
+      profile = media_profile_fixture(%{shorts_behaviour: :exclude})
+      source = source_fixture(%{media_profile_id: profile.id})
+
+      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+        filepath = Keyword.get(addl_opts, :output_filepath)
+
+        contents =
+          Phoenix.json_library().encode!(%{
+            id: "video2",
+            title: "Video 2",
+            original_url: "https://example.com/shorts/video2",
+            was_live: true,
+            description: "desc2"
+          })
+
+        File.write(filepath, contents)
+
+        # Need to add a delay to ensure the file watcher has time to read the file
+        :timer.sleep(watcher_poll_interval * 2)
+        # We know we're testing the file watcher since the syncronous call will only
+        # return an empty string (creating no records)
+        {:ok, ""}
+      end)
+
+      SourceTasks.index_and_enqueue_download_for_media_items(source)
+      refute_enqueued(worker: VideoDownloadWorker)
     end
   end
 

--- a/test/pinchflat/utils/filesystem_utils/file_follower_server_test.exs
+++ b/test/pinchflat/utils/filesystem_utils/file_follower_server_test.exs
@@ -1,0 +1,52 @@
+defmodule Pinchflat.Utils.FilesystemUtils.FileFollowerServerTest do
+  use ExUnit.Case, async: true
+
+  alias alias Pinchflat.Utils.FilesystemUtils
+  alias Pinchflat.Utils.FilesystemUtils.FileFollowerServer
+
+  setup do
+    {:ok, pid} = FileFollowerServer.start_link()
+    tmpfile = FilesystemUtils.generate_metadata_tmpfile(:txt)
+
+    {:ok, %{pid: pid, tmpfile: tmpfile}}
+  end
+
+  describe "watch_file" do
+    test "calls the handler for each existing line in the file", %{pid: pid, tmpfile: tmpfile} do
+      File.write!(tmpfile, "line1\nline2")
+      parent = self()
+
+      handler = fn line -> send(parent, line) end
+      FileFollowerServer.watch_file(pid, tmpfile, handler)
+
+      assert_receive "line1\n"
+      assert_receive "line2"
+    end
+
+    test "calls the handler for each new line in the file", %{pid: pid, tmpfile: tmpfile} do
+      parent = self()
+      file = File.open!(tmpfile, [:append])
+      handler = fn line -> send(parent, line) end
+
+      FileFollowerServer.watch_file(pid, tmpfile, handler)
+
+      IO.binwrite(file, "line1\n")
+      assert_receive "line1\n"
+      IO.binwrite(file, "line2")
+      assert_receive "line2"
+    end
+  end
+
+  describe "stop" do
+    test "stops the watcher", %{pid: pid, tmpfile: tmpfile} do
+      handler = fn _line -> :noop end
+      FileFollowerServer.watch_file(pid, tmpfile, handler)
+
+      refute is_nil(Process.info(pid))
+      FileFollowerServer.stop(pid)
+      # Gotta wait for the server to stop async
+      :timer.sleep(10)
+      assert is_nil(Process.info(pid))
+    end
+  end
+end

--- a/test/pinchflat/utils/filesystem_utils_test.exs
+++ b/test/pinchflat/utils/filesystem_utils_test.exs
@@ -1,0 +1,16 @@
+defmodule Pinchflat.Utils.FilesystemUtilsTest do
+  use ExUnit.Case, async: true
+
+  alias Pinchflat.Utils.FilesystemUtils
+
+  describe "generate_metadata_tmpfile/1" do
+    test "creates a tmpfile and returns its path" do
+      res = FilesystemUtils.generate_metadata_tmpfile(:json)
+
+      assert String.ends_with?(res, ".json")
+      assert File.exists?(res)
+
+      File.rm!(res)
+    end
+  end
+end

--- a/test/pinchflat/workers/media_indexing_worker_test.exs
+++ b/test/pinchflat/workers/media_indexing_worker_test.exs
@@ -13,7 +13,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
 
   describe "perform/1" do
     test "it indexes the source if it should be indexed" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: 10)
 
@@ -21,7 +21,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it indexes the source no matter what if the source has never been indexed before" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: 0, last_indexed_at: nil)
 
@@ -29,7 +29,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it does not do any indexing if the source has been indexed and shouldn't be rescheduled" do
-      expect(YtDlpRunnerMock, :run, 0, fn _url, _opts, _ot -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, 0, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: -1, last_indexed_at: DateTime.utc_now())
 
@@ -37,7 +37,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it does not reschedule if the source shouldn't be indexed" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, ""} end)
+      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: -1)
       perform_job(MediaIndexingWorker, %{id: source.id})
@@ -46,7 +46,9 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it kicks off a download job for each pending media item" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, source_attributes_return_fixture()} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture()}
+      end)
 
       source = source_fixture(index_frequency_minutes: 10)
       perform_job(MediaIndexingWorker, %{id: source.id})
@@ -55,7 +57,9 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it starts a job for any pending media item even if it's from another run" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, source_attributes_return_fixture()} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture()}
+      end)
 
       source = source_fixture(index_frequency_minutes: 10)
       media_item_fixture(%{source_id: source.id, media_filepath: nil})
@@ -65,7 +69,9 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it does not kick off a job for media items that could not be saved" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, source_attributes_return_fixture()} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture()}
+      end)
 
       source = source_fixture(index_frequency_minutes: 10)
       media_item_fixture(%{source_id: source.id, media_filepath: nil, media_id: "video1"})
@@ -76,7 +82,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it reschedules the job based on the index frequency" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: 10)
       perform_job(MediaIndexingWorker, %{id: source.id})
@@ -89,7 +95,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it creates a task for the rescheduled job" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: 10)
       task_count_fetcher = fn -> Enum.count(Tasks.list_tasks()) end
@@ -100,7 +106,7 @@ defmodule Pinchflat.Workers.MediaIndexingWorkerTest do
     end
 
     test "it creates the basic media_item records" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, source_attributes_return_fixture()} end)
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, source_attributes_return_fixture()} end)
 
       source = source_fixture(index_frequency_minutes: 10)
 


### PR DESCRIPTION
## What's new?

- Adds behaviour to indexing that listens to the file `yt-dlp` writes to and creates `MediaItem` records as they come in
  - This HUGELY improves the indexing process since it used to run indexing -> creation -> downloading in serial
- Adds behaviour to the above to enqueue download of media items post-index
- Adds `FileSystemUtils` module with `generate_metadata_tmpfile` method to generate a blank tmpfile of a given type
- Adds a `FileFollowerServer` method for listening to file changes and performing actions on just the changes

## What's changed?

- Updates command runner to optionally take a filepath of the file it'll write its output to
- Removes `command_opts` arg from `VideoCollection.get_media_attributes` since it was unused
- Renames `index_media_items` in `SourceTasks` to `index_and_enqueue_download_for_media_items` to better reflect its purpose
- Updates `index_and_enqueue_download_for_media_items` to now kickoff downloads for pending media itself without needing to call `enqueue_pending_media_tasks` specifically

## What's fixed?

N/A

## Any other comments?

N/A
