### PR TITLE
Add image tag input to Github actions

### DIFF
--- a/.github/workflows/build_and_push_docker.yml
+++ b/.github/workflows/build_and_push_docker.yml
@@ -2,6 +2,11 @@ name: Build and Push Docker Image
 
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker Image Tag'
+        required: true
+        default: 'dev'
 
 jobs:
   docker:
@@ -24,4 +29,4 @@ jobs:
         with:
           push: true
           file: ./selfhosted.Dockerfile
-          tags: keglin/pinchflat:dev
+          tags: 'keglin/pinchflat:${{ github.event.inputs.image_tag }}'


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Updates docker build runner to optionally accept the tag you want to attach to the build

## What's fixed?

N/A

## Any other comments?

N/A
