### PR TITLE
[Bugfix] Resolves bug with null values in search

### DIFF
--- a/lib/pinchflat/media.ex
+++ b/lib/pinchflat/media.ex
@@ -105,9 +105,9 @@ defmodule Pinchflat.Media do
       select_merge: %{
         matching_search_term:
           fragment("""
-            snippet(media_items_search_index, 0, '[PF_HIGHLIGHT]', '[/PF_HIGHLIGHT]', '...', 20) ||
+            coalesce(snippet(media_items_search_index, 0, '[PF_HIGHLIGHT]', '[/PF_HIGHLIGHT]', '...', 20), '') ||
             ' ' ||
-            snippet(media_items_search_index, 1, '[PF_HIGHLIGHT]', '[/PF_HIGHLIGHT]', '...', 20)
+            coalesce(snippet(media_items_search_index, 1, '[PF_HIGHLIGHT]', '[/PF_HIGHLIGHT]', '...', 20), '')
           """)
       },
       order_by: [desc: fragment("rank")],

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -267,6 +267,13 @@ defmodule Pinchflat.MediaTest do
       assert String.contains?(res.matching_search_term, "The [PF_HIGHLIGHT]quick[/PF_HIGHLIGHT] brown fox")
     end
 
+    test "doesn't set matching_search_term to nil if one of the attributes we search on is null" do
+      media_item_fixture(%{title: "foobar baz", description: nil})
+
+      assert [%{matching_search_term: matching_search_term}] = Media.search("baz")
+      refute is_nil(matching_search_term)
+    end
+
     test "optionally lets you specify a limit" do
       media_item_fixture(%{title: "The small gray dog"})
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Fixed a bug where searching would throw an error if one of the searchable columns (ie: title, description) is null, regardless of whether that column contained a search term
  - The issue is that passing `null` to SQLite's `snippet` would make it return `null` and breaking the whole concatenation routine. So `matching_search_term` would get set to `nil`, later breaking the UI highlight function because it tries to call `String.split/3` on `nil`
  - The fix is to coalesce the `snippet` calls so they always return a string

## Any other comments?

N/A
