### PR TITLE
Improve short detection

### DIFF
--- a/lib/pinchflat/media.ex
+++ b/lib/pinchflat/media.ex
@@ -189,16 +189,9 @@ defmodule Pinchflat.Media do
   Returns {:ok, %MediaItem{}} | {:error, %Ecto.Changeset{}}
   """
   def create_media_item_from_backend_attrs(source, media_attrs_struct) do
-    attrs = %{
-      source_id: source.id,
-      title: media_attrs_struct.title,
-      media_id: media_attrs_struct.media_id,
-      original_url: media_attrs_struct.original_url,
-      livestream: media_attrs_struct.livestream,
-      description: media_attrs_struct.description
-    }
-
-    create_media_item(attrs)
+    %{source_id: source.id}
+    |> Map.merge(Map.from_struct(media_attrs_struct))
+    |> create_media_item()
   end
 
   @doc """

--- a/lib/pinchflat/media.ex
+++ b/lib/pinchflat/media.ex
@@ -188,14 +188,14 @@ defmodule Pinchflat.Media do
 
   Returns {:ok, %MediaItem{}} | {:error, %Ecto.Changeset{}}
   """
-  def create_media_item_from_backend_attrs(source, media_attrs) do
+  def create_media_item_from_backend_attrs(source, media_attrs_struct) do
     attrs = %{
       source_id: source.id,
-      title: media_attrs["title"],
-      media_id: media_attrs["id"],
-      original_url: media_attrs["original_url"],
-      livestream: media_attrs["was_live"],
-      description: media_attrs["description"]
+      title: media_attrs_struct.title,
+      media_id: media_attrs_struct.media_id,
+      original_url: media_attrs_struct.original_url,
+      livestream: media_attrs_struct.livestream,
+      description: media_attrs_struct.description
     }
 
     create_media_item(attrs)

--- a/lib/pinchflat/media.ex
+++ b/lib/pinchflat/media.ex
@@ -257,7 +257,7 @@ defmodule Pinchflat.Media do
         {{:shorts_behaviour, :only}, %{livestream_behaviour: :only}} ->
           dynamic(
             [mi],
-            ^dynamic and (mi.livestream == true or fragment("LOWER(?) LIKE LOWER(?)", mi.original_url, "%/shorts/%"))
+            ^dynamic and (mi.livestream == true or mi.short_form_content == true)
           )
 
         # Technically redundant, but makes the other clauses easier to parse
@@ -266,16 +266,13 @@ defmodule Pinchflat.Media do
           dynamic
 
         {{:shorts_behaviour, :only}, _} ->
-          # return records with /shorts/ in the original_url
-          dynamic([mi], ^dynamic and fragment("LOWER(?) LIKE LOWER(?)", mi.original_url, "%/shorts/%"))
+          dynamic([mi], ^dynamic and mi.short_form_content == true)
 
         {{:livestream_behaviour, :only}, _} ->
-          # return records with livestream: true
           dynamic([mi], ^dynamic and mi.livestream == true)
 
         {{:shorts_behaviour, :exclude}, %{livestream_behaviour: lb}} when lb != :only ->
-          # return records without /shorts/ in the original_url
-          dynamic([mi], ^dynamic and fragment("LOWER(?) NOT LIKE LOWER(?)", mi.original_url, "%/shorts/%"))
+          dynamic([mi], ^dynamic and mi.short_form_content == false)
 
         {{:livestream_behaviour, :exclude}, %{shorts_behaviour: sb}} when sb != :only ->
           # return records with livestream: false

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -19,6 +19,7 @@ defmodule Pinchflat.Media.MediaItem do
     :original_url,
     :livestream,
     :source_id,
+    :short_form_content,
     # these fields are captured only on download
     :media_downloaded_at,
     :media_filepath,
@@ -27,7 +28,7 @@ defmodule Pinchflat.Media.MediaItem do
     :thumbnail_filepath,
     :metadata_filepath
   ]
-  @required_fields ~w(title original_url livestream media_id source_id)a
+  @required_fields ~w(title original_url livestream media_id source_id short_form_content)a
 
   schema "media_items" do
     field :title, :string
@@ -35,6 +36,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :description, :string
     field :original_url, :string
     field :livestream, :boolean, default: false
+    field :short_form_content, :boolean, default: false
     field :media_downloaded_at, :utc_datetime
 
     field :media_filepath, :string

--- a/lib/pinchflat/tasks/source_tasks.ex
+++ b/lib/pinchflat/tasks/source_tasks.ex
@@ -20,6 +20,8 @@ defmodule Pinchflat.Tasks.SourceTasks do
   alias Pinchflat.Workers.MediaCollectionIndexingWorker
   alias Pinchflat.Utils.FilesystemUtils.FileFollowerServer
 
+  alias Pinchflat.YtDlp.Backend.Media, as: YtDlpMedia
+
   @doc """
   Starts tasks for indexing a source's media regardless of the source's indexing
   frequency. It's assumed the caller will check for that.
@@ -162,7 +164,8 @@ defmodule Pinchflat.Tasks.SourceTasks do
         {:ok, media_attrs} ->
           Logger.debug("FileFollowerServer Handler: Got media attributes: #{inspect(media_attrs)}")
 
-          create_media_item_and_enqueue_download(source, media_attrs)
+          media_struct = YtDlpMedia.response_to_struct(media_attrs)
+          create_media_item_and_enqueue_download(source, media_struct)
 
         err ->
           Logger.debug("FileFollowerServer Handler: Error decoding JSON: #{inspect(err)}")

--- a/lib/pinchflat/yt_dlp/backend/media.ex
+++ b/lib/pinchflat/yt_dlp/backend/media.ex
@@ -3,12 +3,22 @@ defmodule Pinchflat.YtDlp.Backend.Media do
   Contains utilities for working with singular pieces of media
   """
 
+  @enforce_keys [
+    :media_id,
+    :title,
+    :description,
+    :original_url,
+    :livestream,
+    :short_form_content
+  ]
+
   defstruct [
     :media_id,
     :title,
     :description,
     :original_url,
-    :livestream
+    :livestream,
+    :short_form_content
   ]
 
   alias __MODULE__
@@ -57,18 +67,37 @@ defmodule Pinchflat.YtDlp.Backend.Media do
   Returns the output template for yt-dlp's indexing command.
   """
   def indexing_output_template do
-    "%(.{id,title,was_live,original_url,description})j"
+    "%(.{id,title,was_live,webpage_url,description,aspect_ratio,duration})j"
   end
 
-  # TODO: test
+  @doc """
+  Transforms a response from yt-dlp into a struct. Interprets the response to
+  determine if the media is short-form content.
+
+  Returns %Media{}.
+  """
   def response_to_struct(response) do
     %Media{
       media_id: response["id"],
       title: response["title"],
       description: response["description"],
-      original_url: response["original_url"],
-      livestream: response["was_live"]
+      original_url: response["webpage_url"],
+      livestream: response["was_live"],
+      short_form_content: short_form_content?(response)
     }
+  end
+
+  defp short_form_content?(response) do
+    if String.contains?(response["webpage_url"], "/shorts/") do
+      true
+    else
+      # Sometimes shorts are returned without /shorts/ in the URL,
+      # so we need to do our best to determine if it's a short. This
+      # WILL returns false positives, but it's a best-effort approach
+      # that should work for most cases. The aspect_ratio check is
+      # based on a gut feeling and may need to be tweaked.
+      response["duration"] <= 60 && response["aspect_ratio"] < 0.8
+    end
   end
 
   defp backend_runner do

--- a/lib/pinchflat/yt_dlp/backend/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/backend/media_collection.ex
@@ -36,6 +36,7 @@ defmodule Pinchflat.YtDlp.Backend.MediaCollection do
         output
         |> String.split("\n", trim: true)
         |> Enum.map(&Phoenix.json_library().decode!/1)
+        |> Enum.map(&YtDlpMedia.response_to_struct/1)
         |> FunctionUtils.wrap_ok()
 
       res ->

--- a/priv/repo/migrations/20240309052602_add_short_form_to_media_items.exs
+++ b/priv/repo/migrations/20240309052602_add_short_form_to_media_items.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddShortFormToMediaItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_items) do
+      add :short_form_content, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -97,7 +97,7 @@ defmodule Pinchflat.MediaTest do
     test "returns shorts and normal media when shorts_behaviour is :include" do
       source = source_fixture(%{media_profile_id: media_profile_fixture(%{shorts_behaviour: :include}).id})
       normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
-      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [normal, short]
     end
@@ -105,7 +105,7 @@ defmodule Pinchflat.MediaTest do
     test "returns only shorts when shorts_behaviour is :only" do
       source = source_fixture(%{media_profile_id: media_profile_fixture(%{shorts_behaviour: :only}).id})
       _normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
-      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [short]
     end
@@ -113,7 +113,7 @@ defmodule Pinchflat.MediaTest do
     test "returns only normal media when shorts_behaviour is :exclude" do
       source = source_fixture(%{media_profile_id: media_profile_fixture(%{shorts_behaviour: :exclude}).id})
       normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
-      _short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      _short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [normal]
     end
@@ -158,7 +158,7 @@ defmodule Pinchflat.MediaTest do
 
       normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
       livestream = media_item_fixture(%{source_id: source.id, media_filepath: nil, livestream: true})
-      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [normal, livestream, short]
     end
@@ -175,7 +175,7 @@ defmodule Pinchflat.MediaTest do
 
       _normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
       livestream = media_item_fixture(%{source_id: source.id, media_filepath: nil, livestream: true})
-      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [livestream, short]
     end
@@ -192,7 +192,7 @@ defmodule Pinchflat.MediaTest do
 
       normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
       _livestream = media_item_fixture(%{source_id: source.id, media_filepath: nil, livestream: true})
-      _short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      _short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [normal]
     end
@@ -209,7 +209,7 @@ defmodule Pinchflat.MediaTest do
 
       _normal = media_item_fixture(%{source_id: source.id, media_filepath: nil})
       _livestream = media_item_fixture(%{source_id: source.id, media_filepath: nil, livestream: true})
-      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      short = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       assert Media.list_pending_media_items_for(source) == [short]
     end
@@ -249,7 +249,7 @@ defmodule Pinchflat.MediaTest do
 
     test "returns false if the media hasn't been downloaded but the profile doesn't DL shorts" do
       source = source_fixture(%{media_profile_id: media_profile_fixture(%{shorts_behaviour: :exclude}).id})
-      media_item = media_item_fixture(%{source_id: source.id, media_filepath: nil, original_url: "/shorts/"})
+      media_item = media_item_fixture(%{source_id: source.id, media_filepath: nil, short_form_content: true})
 
       refute Media.pending_download?(media_item)
     end

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -11,6 +11,8 @@ defmodule Pinchflat.MediaTest do
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Metadata.MetadataFileHelpers
 
+  alias Pinchflat.YtDlp.Backend.Media, as: YtDlpMedia
+
   setup :verify_on_exit!
 
   @invalid_attrs %{title: nil, media_id: nil, media_filepath: nil}
@@ -388,14 +390,18 @@ defmodule Pinchflat.MediaTest do
   describe "create_media_item_from_backend_attrs/2" do
     test "creates a media item for a given source and attributes" do
       source = source_fixture()
-      media_attrs = Phoenix.json_library().decode!(media_attributes_return_fixture())
+
+      media_attrs =
+        media_attributes_return_fixture()
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
 
       assert {:ok, %MediaItem{} = media_item} = Media.create_media_item_from_backend_attrs(source, media_attrs)
       assert media_item.source_id == source.id
-      assert media_item.title == media_attrs["title"]
-      assert media_item.media_id == media_attrs["id"]
-      assert media_item.original_url == media_attrs["original_url"]
-      assert media_item.description == media_attrs["description"]
+      assert media_item.title == media_attrs.title
+      assert media_item.media_id == media_attrs.media_id
+      assert media_item.original_url == media_attrs.original_url
+      assert media_item.description == media_attrs.description
     end
   end
 

--- a/test/pinchflat/tasks/media_items_tasks_test.exs
+++ b/test/pinchflat/tasks/media_items_tasks_test.exs
@@ -84,9 +84,11 @@ defmodule Pinchflat.Tasks.MediaItemTasksTest do
           Phoenix.json_library().encode!(%{
             id: "video2",
             title: "Video 2",
-            original_url: "https://example.com/shorts/video2",
+            webpage_url: "https://example.com/shorts/video2",
             was_live: true,
-            description: "desc2"
+            description: "desc2",
+            aspect_ratio: 1.67,
+            duration: 345.67
           })
 
         {:ok, output}

--- a/test/pinchflat/tasks/source_tasks_test.exs
+++ b/test/pinchflat/tasks/source_tasks_test.exs
@@ -229,9 +229,11 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
           Phoenix.json_library().encode!(%{
             id: "video2",
             title: "Video 2",
-            original_url: "https://example.com/shorts/video2",
+            webpage_url: "https://example.com/shorts/video2",
             was_live: true,
-            description: "desc2"
+            description: "desc2",
+            aspect_ratio: 1.67,
+            duration: 345.67
           })
 
         File.write(filepath, contents)

--- a/test/pinchflat/yt_dlp/backend/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/backend/media_collection_test.exs
@@ -16,7 +16,7 @@ defmodule Pinchflat.YtDlp.Backend.MediaCollectionTest do
         {:ok, source_attributes_return_fixture() <> "\n\n"}
       end)
 
-      assert {:ok, [%{"id" => "video1"}, %{"id" => "video2"}, %{"id" => "video3"}]} =
+      assert {:ok, [%Media{media_id: "video1"}, %Media{media_id: "video2"}, %Media{media_id: "video3"}]} =
                MediaCollection.get_media_attributes_for_collection(@channel_url)
     end
 

--- a/test/pinchflat/yt_dlp/backend/media_test.exs
+++ b/test/pinchflat/yt_dlp/backend/media_test.exs
@@ -55,7 +55,7 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
         {:ok, media_attributes_return_fixture()}
       end)
 
-      assert {:ok, %{"description" => _, "id" => _, "original_url" => _, "title" => _, "was_live" => _}} =
+      assert {:ok, %{description: _, media_id: _, original_url: _, title: _, livestream: _}} =
                Media.get_media_attributes(@media_url)
     end
 

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -19,6 +19,7 @@ defmodule Pinchflat.MediaFixtures do
         title: Faker.Commerce.product_name(),
         original_url: "https://www.youtube.com/watch?v=#{media_id}",
         livestream: false,
+        short_form_content: false,
         media_filepath: "/video/#{Faker.File.file_name(:video)}",
         source_id: SourcesFixtures.source_fixture().id
       })

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -71,9 +71,11 @@ defmodule Pinchflat.MediaFixtures do
     media_attributes = %{
       id: "video1",
       title: "Video 1",
-      original_url: "https://example.com/video1",
+      webpage_url: "https://example.com/video1",
       was_live: false,
-      description: "desc1"
+      description: "desc1",
+      aspect_ratio: 1.67,
+      duration: 123.45
     }
 
     Phoenix.json_library().encode!(media_attributes)

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -35,23 +35,29 @@ defmodule Pinchflat.SourcesFixtures do
       %{
         id: "video1",
         title: "Video 1",
-        original_url: "https://example.com/video1",
+        webpage_url: "https://example.com/video1",
         was_live: false,
-        description: "desc1"
+        description: "desc1",
+        aspect_ratio: 1.67,
+        duration: 12.34
       },
       %{
         id: "video2",
         title: "Video 2",
-        original_url: "https://example.com/video2",
+        webpage_url: "https://example.com/video2",
         was_live: true,
-        description: "desc2"
+        description: "desc2",
+        aspect_ratio: 1.67,
+        duration: 345.67
       },
       %{
         id: "video3",
         title: "Video 3",
-        original_url: "https://example.com/video3",
+        webpage_url: "https://example.com/video3",
         was_live: false,
-        description: "desc3"
+        description: "desc3",
+        aspect_ratio: 1.0,
+        duration: 678.90
       }
     ]
 


### PR DESCRIPTION
## What's new?

- Adds a `short_form_content` field to `MediaItem`
- Adds a new `Media` (from yt-dlp modules) struct and method to transform a response into a struct
  - This method uses the URL, aspect ratio, and duration to try and determine if content is a short

## What's changed?

- Updates yt-dlp media attribute methods to ask for `webpage_url` instead of `original_url`
- Updates yt-dlp media attribute methods to ask for `aspect_ratio` and `duration`

## What's fixed?

N/A

## Any other comments?

N/A
