### PR TITLE
Fast index UI

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -42,6 +42,7 @@ config :pinchflat, Oban,
   # TODO: consider making this an env var or something?
   queues: [
     default: 10,
+    fast_indexing: 6,
     media_indexing: 2,
     media_collection_indexing: 2,
     media_fetching: 2,

--- a/lib/pinchflat/api/youtube_rss.ex
+++ b/lib/pinchflat/api/youtube_rss.ex
@@ -3,6 +3,8 @@ defmodule Pinchflat.Api.YoutubeRss do
   Methods for interacting with YouTube RSS feeds
   """
 
+  require Logger
+
   alias Pinchflat.Sources.Source
 
   @doc """
@@ -11,6 +13,8 @@ defmodule Pinchflat.Api.YoutubeRss do
   Returns {:ok, [binary()]} | {:error, binary()}
   """
   def get_recent_media_ids_from_rss(%Source{} = source) do
+    Logger.debug("Fetching recent media IDs from YouTube RSS feed for source: #{source.collection_id}")
+
     case http_client().get(rss_url_for_source(source)) do
       {:ok, response} ->
         response = to_string(response)
@@ -24,6 +28,8 @@ defmodule Pinchflat.Api.YoutubeRss do
           |> Enum.map(fn [_, id] -> String.trim(id) end)
           |> Enum.filter(&(String.length(&1) > 0))
           |> Enum.uniq()
+
+        Logger.debug("Media ids fetched from RSS: #{inspect(media_ids)}")
 
         {:ok, media_ids}
 

--- a/lib/pinchflat/sources.ex
+++ b/lib/pinchflat/sources.ex
@@ -211,7 +211,8 @@ defmodule Pinchflat.Sources do
             SourceTasks.kickoff_indexing_task(source)
 
           %{index_frequency_minutes: _} ->
-            # TODO: delete the recurring RSS task (when I get there)
+            Tasks.delete_pending_tasks_for(source, "FastIndexingWorker")
+            Tasks.delete_pending_tasks_for(source, "MediaIndexingWorker")
             Tasks.delete_pending_tasks_for(source, "MediaCollectionIndexingWorker")
 
           _ ->

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -17,6 +17,7 @@ defmodule Pinchflat.Sources.Source do
     collection_type
     custom_name
     index_frequency_minutes
+    fast_index
     download_media
     last_indexed_at
     original_url
@@ -29,6 +30,7 @@ defmodule Pinchflat.Sources.Source do
     collection_type
     custom_name
     index_frequency_minutes
+    fast_index
     download_media
     original_url
     media_profile_id
@@ -40,6 +42,7 @@ defmodule Pinchflat.Sources.Source do
     field :collection_id, :string
     field :collection_type, Ecto.Enum, values: [:channel, :playlist]
     field :index_frequency_minutes, :integer, default: 60 * 24
+    field :fast_index, :boolean, default: false
     field :download_media, :boolean, default: true
     field :last_indexed_at, :utc_datetime
     # This should only be used for user reference going forward

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -68,6 +68,13 @@ defmodule Pinchflat.Sources.Source do
 
   @doc false
   def index_frequency_when_fast_indexing do
+    # 30 days in minutes
     60 * 24 * 30
+  end
+
+  @doc false
+  def fast_index_frequency do
+    # minutes
+    15
   end
 end

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -65,4 +65,9 @@ defmodule Pinchflat.Sources.Source do
     |> validate_required(@required_fields)
     |> unique_constraint([:collection_id, :media_profile_id])
   end
+
+  @doc false
+  def index_frequency_when_fast_indexing do
+    60 * 24 * 30
+  end
 end

--- a/lib/pinchflat/workers/fast_indexing_worker.ex
+++ b/lib/pinchflat/workers/fast_indexing_worker.ex
@@ -1,0 +1,42 @@
+defmodule Pinchflat.Workers.FastIndexingWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :fast_indexing,
+    unique: [period: :infinity, states: [:available, :scheduled, :retryable]],
+    tags: ["media_source", "fast_indexing"]
+
+  alias __MODULE__
+  alias Pinchflat.Tasks
+  alias Pinchflat.Sources
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Tasks.SourceTasks
+
+  @impl Oban.Worker
+  @doc """
+  TODO
+  """
+  def perform(%Oban.Job{args: %{"id" => source_id}}) do
+    source = Sources.get_source!(source_id)
+
+    if source.fast_index do
+      SourceTasks.kickoff_indexing_tasks_from_youtube_rss_feed(source)
+
+      reschedule_indexing(source)
+    else
+      :ok
+    end
+  end
+
+  defp reschedule_indexing(source) do
+    next_run_in = Source.fast_index_frequency() * 60
+
+    %{id: source.id}
+    |> FastIndexingWorker.new(schedule_in: next_run_in)
+    |> Tasks.create_job_with_task(source)
+    |> case do
+      {:ok, task} -> {:ok, task}
+      {:error, :duplicate_job} -> {:ok, :job_exists}
+    end
+  end
+end

--- a/lib/pinchflat/workers/media_collection_indexing_worker.ex
+++ b/lib/pinchflat/workers/media_collection_indexing_worker.ex
@@ -9,7 +9,9 @@ defmodule Pinchflat.Workers.MediaCollectionIndexingWorker do
   alias __MODULE__
   alias Pinchflat.Tasks
   alias Pinchflat.Sources
+  alias Pinchflat.Sources.Source
   alias Pinchflat.Tasks.SourceTasks
+  alias Pinchflat.Workers.FastIndexingWorker
 
   @impl Oban.Worker
   @doc """
@@ -30,6 +32,27 @@ defmodule Pinchflat.Workers.MediaCollectionIndexingWorker do
     actually run every 1 hour and 30 minutes. The tradeoff of not inundating
     the API with requests and also not overlapping jobs is worth it, IMO.
 
+  Order of operations:
+    1. The user saves a source
+    2. This job is automatically scheduled immediately. This happens in all cases.
+    3. This job indexes all content for the given source. A download job is
+       enqueued for each media item that should be downloaded. This can be impacted
+       by the `download_media` field on the source as well as the profile's
+       shorts/livestream behaviour. At this step we also attach a file reader
+       to the `yt-dlp` output file so we can create media items as they come in
+       for a little speedup (see SourceTasks comments for more)
+    4. If this job is meant to reschedule (ie: has an index frequency > 0),
+       it reschedules itself. If not, it runs once and does not reschedule
+    5. If the source uses fast indexing, that job is kicked off as well. It
+       uses RSS to run a smaller, faster, and more frequent index. That job
+       handles rescheduling itself but largely has a similar behaviour to this
+       job in that it kicks off index and maybe download jobs. The biggest difference
+       is that an index job is kicked off _for each new media item_ as opposed
+       to one larger index job. Check out `MediaIndexingWorker` comments for more.
+    6. If the job reschedules, the cycle from step 3 repeats until the heat death
+       of the universe. The user changing things like the index frequency can
+       dequeue or reschedule jobs as well
+
   NOTE: Since indexing can take a LONG time, I should check what happens if an
   application restart occurs while a job is running. Will the job be lost?
 
@@ -44,6 +67,7 @@ defmodule Pinchflat.Workers.MediaCollectionIndexingWorker do
       {index_freq, _} when index_freq > 0 ->
         # If the indexing is on a schedule simply run indexing and reschedule
         SourceTasks.index_and_enqueue_download_for_media_items(source)
+        maybe_enqueue_fast_indexing_task(source)
         reschedule_indexing(source)
 
       {_, nil} ->
@@ -60,12 +84,26 @@ defmodule Pinchflat.Workers.MediaCollectionIndexingWorker do
   end
 
   defp reschedule_indexing(source) do
+    next_run_in = source.index_frequency_minutes * 60
+
     %{id: source.id}
-    |> MediaCollectionIndexingWorker.new(schedule_in: source.index_frequency_minutes * 60)
+    |> MediaCollectionIndexingWorker.new(schedule_in: next_run_in)
     |> Tasks.create_job_with_task(source)
     |> case do
       {:ok, task} -> {:ok, task}
       {:error, :duplicate_job} -> {:ok, :job_exists}
+    end
+  end
+
+  defp maybe_enqueue_fast_indexing_task(source) do
+    if source.fast_index do
+      Tasks.delete_pending_tasks_for(source, "FastIndexingWorker")
+
+      next_run_in = Source.fast_index_frequency() * 60
+
+      %{id: source.id}
+      |> FastIndexingWorker.new(schedule_in: next_run_in)
+      |> Tasks.create_job_with_task(source)
     end
   end
 end

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -3,8 +3,9 @@ defmodule PinchflatWeb.Sources.SourceController do
 
   alias Pinchflat.Repo
   alias Pinchflat.Media
-  alias Pinchflat.Profiles
+  alias Pinchflat.Tasks
   alias Pinchflat.Sources
+  alias Pinchflat.Profiles
   alias Pinchflat.Sources.Source
 
   def index(conn, _params) do
@@ -43,15 +44,18 @@ defmodule PinchflatWeb.Sources.SourceController do
   end
 
   def show(conn, %{"id" => id}) do
-    source =
-      id
-      |> Sources.get_source!()
-      |> Repo.preload([:media_profile, tasks: [:job]])
+    source = Repo.preload(Sources.get_source!(id), :media_profile)
 
+    pending_tasks = Repo.preload(Tasks.list_pending_tasks_for(:source_id, source.id), :job)
     pending_media = Media.list_pending_media_items_for(source, limit: 100)
     downloaded_media = Media.list_downloaded_media_items_for(source, limit: 100)
 
-    render(conn, :show, source: source, pending_media: pending_media, downloaded_media: downloaded_media)
+    render(conn, :show,
+      source: source,
+      pending_tasks: pending_tasks,
+      pending_media: pending_media,
+      downloaded_media: downloaded_media
+    )
   end
 
   def edit(conn, %{"id" => id}) do

--- a/lib/pinchflat_web/controllers/sources/source_html/fast_indexing_help.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/fast_indexing_help.html.heex
@@ -1,0 +1,21 @@
+<aside>
+  <h2 class="text-xl font-bold mb-2">What is fast indexing (experimental)?</h2>
+  <section class="ml-2 md:ml-4 mb-4 max-w-prose">
+    <p>
+      Indexing is the act of scanning a channel or playlist (aka: source) for new media.
+    </p>
+    <p class="mt-2">
+      Normal indexing uses <code class="text-sm">yt-dlp</code>
+      to scan the entire source on your specified frequency, but it's very slow for large sources. This is the most accurate way to find uploaded media with the tradeoff being that pairing a large source with a low index frequency will result in you spending most of your time indexing. Only so many indexing operations can be running at the same time, so this can impact your other source's ability to index.
+    </p>
+    <p class="mt-2">
+      Fast indexing takes a different approach. It still does an initial scan the slow way but after that it uses an RSS feed to frequently check for new videos. This has the potential to be hundreds of times faster, but it can miss videos if the uploader un-privates an old video or uploads dozens of videos in the space of a few minutes. It works well for most channels or playlists but it's not perfect.
+    </p>
+    <p class="mt-2">
+      To make up for this limitation, a normal index is still run monthly to catch any videos that were missed by fast indexing. Fast indexing overrides the normal index frequency.
+    </p>
+    <p class="mt-2">
+      Fast indexing is experimental so please report any issues on GitHub. It's only recommended for sources with over 200-ish videos and that upload frequently. Not recommended for small or inactive sources.
+    </p>
+  </section>
+</aside>

--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -84,9 +84,9 @@
           <p class="text-black dark:text-white">Nothing Here!</p>
         <% end %>
       </:tab>
-      <:tab title="Tasks">
-        <%= if match?([_|_], @source.tasks) do %>
-          <.table rows={@source.tasks} table_class="text-black dark:text-white">
+      <:tab title="Pending Tasks">
+        <%= if match?([_|_], @pending_tasks) do %>
+          <.table rows={@pending_tasks} table_class="text-black dark:text-white">
             <:col :let={task} label="Worker">
               <%= task.job.worker %>
             </:col>

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -3,6 +3,10 @@
     Oops, something went wrong! Please check the errors below.
   </.error>
 
+  <h3 class="mt-8 text-2xl text-black dark:text-white">
+    General Options
+  </h3>
+
   <.input
     field={f[:custom_name]}
     type="text"
@@ -19,6 +23,10 @@
     label="Media Profile"
   />
 
+  <h3 class="mt-8 text-2xl text-black dark:text-white">
+    Indexing Options
+  </h3>
+
   <.input
     field={f[:index_frequency_minutes]}
     options={friendly_index_frequencies()}
@@ -27,6 +35,18 @@
     help="Time between one index of this source finishing and the next one starting. Setting to 'On Create' will still run an initial index but no subsequent ones"
   />
 
+  <%!-- TODO: use Alpine to disable the index frequency when fast indexing is enabled --%>
+  <.input
+    field={f[:fast_index]}
+    type="toggle"
+    label="Use Fast Indexing?"
+    help="Experimental. Ignores 'Index Frequency'. Recommended for large channels that upload frequently. See below for more info"
+  />
+
+  <h3 class="mt-8 text-2xl text-black dark:text-white">
+    Downloading Options
+  </h3>
+
   <.input
     field={f[:download_media]}
     type="toggle"
@@ -34,7 +54,9 @@
     help="Unchecking still indexes media but it won't be downloaded until you enable this option"
   />
 
-  <:actions>
-    <.button class="my-10 sm:mb-7.5 w-full sm:w-auto">Save Source</.button>
-  </:actions>
+  <.button class="my-10 sm:mb-7.5 w-full sm:w-auto">Save Source</.button>
+
+  <div class="rounded-sm dark:bg-meta-4 p-4 md:p-6 mb-5">
+    <.fast_indexing_help />
+  </div>
 </.simple_form>

--- a/priv/repo/migrations/20240309182418_add_fast_index_to_sources.exs
+++ b/priv/repo/migrations/20240309182418_add_fast_index_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddFastIndexToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :fast_index, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/pinchflat/tasks/source_tasks_test.exs
+++ b/test/pinchflat/tasks/source_tasks_test.exs
@@ -66,6 +66,34 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
     end
   end
 
+  describe "kickoff_fast_indexing_task/1" do
+    test "it schedules a job" do
+      source = source_fixture()
+
+      assert {:ok, _} = SourceTasks.kickoff_fast_indexing_task(source)
+
+      assert_enqueued(worker: FastIndexingWorker, args: %{"id" => source.id})
+    end
+
+    test "it creates and attaches a task" do
+      source = source_fixture()
+
+      assert {:ok, %Task{} = task} = SourceTasks.kickoff_fast_indexing_task(source)
+
+      assert task.source_id == source.id
+    end
+
+    test "it deletes any fast indexing tasks for the source" do
+      source = source_fixture()
+      {:ok, job} = Oban.insert(FastIndexingWorker.new(%{"id" => source.id}))
+      task = task_fixture(source_id: source.id, job_id: job.id)
+
+      assert {:ok, _} = SourceTasks.kickoff_fast_indexing_task(source)
+
+      assert_raise Ecto.NoResultsError, fn -> Repo.reload!(task) end
+    end
+  end
+
   describe "kickoff_indexing_tasks_from_youtube_rss_feed/1" do
     setup do
       {:ok, [source: source_fixture()]}

--- a/test/pinchflat/workers/fast_indexing_worker_test.exs
+++ b/test/pinchflat/workers/fast_indexing_worker_test.exs
@@ -1,0 +1,46 @@
+defmodule Pinchflat.Workers.FastIndexingWorkerTest do
+  use Pinchflat.DataCase
+
+  import Mox
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Workers.FastIndexingWorker
+
+  setup :verify_on_exit!
+
+  describe "perform/1" do
+    test "calls out to Youtube RSS if enabled" do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
+      source = source_fixture(fast_index: true)
+
+      perform_job(FastIndexingWorker, %{"id" => source.id})
+    end
+
+    test "reschedules itself if fast indexing is enabled" do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
+      source = source_fixture(fast_index: true)
+      perform_job(FastIndexingWorker, %{"id" => source.id})
+
+      assert_enqueued(
+        worker: FastIndexingWorker,
+        args: %{"id" => source.id},
+        scheduled_at: now_plus(Source.fast_index_frequency(), :minutes)
+      )
+    end
+
+    test "does not call out to Youtube RSS if disabled" do
+      expect(HTTPClientMock, :get, 0, fn _url -> {:ok, ""} end)
+      source = source_fixture(fast_index: false)
+
+      perform_job(FastIndexingWorker, %{"id" => source.id})
+    end
+
+    test "does not reschedule itself if fast indexing is disabled" do
+      source = source_fixture(fast_index: false)
+      perform_job(FastIndexingWorker, %{"id" => source.id})
+
+      refute_enqueued(worker: FastIndexingWorker, args: %{"id" => source.id})
+    end
+  end
+end


### PR DESCRIPTION
## What's new?

- Adds `fast_index` field to sources and hooked up all lifecycle updates around it
- Adds fast indexing worker and hooked it up to other indexing workers

## What's changed?

- Updated sources UI to now only show pending tasks instead of all tasks

## What's fixed?

N/A

## Any other comments?

N/A
