### PR TITLE
Local data worker improvements

### DIFF
--- a/lib/pinchflat/application.ex
+++ b/lib/pinchflat/application.ex
@@ -10,9 +10,9 @@ defmodule Pinchflat.Application do
     children = [
       PinchflatWeb.Telemetry,
       Pinchflat.Repo,
-      # {Task, &run_startup_tasks/0},
-      Pinchflat.StartupTasks,
+      # Must be before startup tasks
       {Oban, Application.fetch_env!(:pinchflat, Oban)},
+      Pinchflat.StartupTasks,
       {DNSCluster, query: Application.get_env(:pinchflat, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Pinchflat.PubSub},
       # Start the Finch HTTP client for sending emails

--- a/lib/pinchflat/workers/data_backfill_worker.ex
+++ b/lib/pinchflat/workers/data_backfill_worker.ex
@@ -1,0 +1,59 @@
+defmodule Pinchflat.Workers.DataBackfillWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :media_local_metadata,
+    unique: [period: :infinity, states: [:available, :scheduled, :retryable]],
+    tags: ["media_item", "media_metadata", "local_metadata", "data_backfill"]
+
+  # This one is going to be a little more self-contained
+  # instead of relying on outside modules for the methods.
+  # That's because, for now, these methods are not intended
+  # to be used elsewhere.
+  #
+  # I'm just trying out that pattern and seeing if I like it better
+  # so this may change.
+  import Ecto.Query, warn: false
+
+  alias __MODULE__
+  alias Pinchflat.Repo
+  alias Pinchflat.Media.MediaItem
+
+  @impl Oban.Worker
+  @doc """
+  Performs one-off tasks to get data in the right shape.
+  This can be needed when we add new features or change the way
+  we store data. Must be idempotent. All new data should already
+  conform to the expected schema so this should only be needed
+  for existing data. Still runs periodically to be safe.
+
+  Returns :ok
+  """
+  def perform(%Oban.Job{}) do
+    backfill_shorts_data()
+
+    reschedule_backfill()
+
+    :ok
+  end
+
+  defp backfill_shorts_data do
+    query =
+      from(
+        m in MediaItem,
+        where: fragment("? like ?", m.original_url, "%/shorts/%"),
+        where: m.short_form_content == false
+      )
+
+    Repo.update_all(query, set: [short_form_content: true])
+  end
+
+  defp reschedule_backfill do
+    # Run hourly
+    next_run_in = 60 * 60
+
+    %{}
+    |> DataBackfillWorker.new(schedule_in: next_run_in)
+    |> Repo.insert_unique_job()
+  end
+end

--- a/lib/pinchflat/workers/fast_indexing_worker.ex
+++ b/lib/pinchflat/workers/fast_indexing_worker.ex
@@ -14,7 +14,11 @@ defmodule Pinchflat.Workers.FastIndexingWorker do
 
   @impl Oban.Worker
   @doc """
-  TODO
+  Kicks off the fast indexing process for a source, reschedules the job to run again
+  once complete. See `MediaCollectionIndexingWorker` and `MediaIndexingWorker` comments
+  for more
+
+  Returns :ok | {:ok, :job_exists} | {:ok, %Task{}}
   """
   def perform(%Oban.Job{args: %{"id" => source_id}}) do
     source = Sources.get_source!(source_id)

--- a/test/pinchflat/workers/data_backfill_worker_test.exs
+++ b/test/pinchflat/workers/data_backfill_worker_test.exs
@@ -1,0 +1,37 @@
+defmodule Pinchflat.Workers.DataBackfillWorkerTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+
+  alias Pinchflat.Workers.DataBackfillWorker
+
+  describe "perform/1" do
+    test "reschedules itself once complete" do
+      perform_job(DataBackfillWorker, %{})
+
+      assert_enqueued(worker: DataBackfillWorker, scheduled_at: now_plus(60, :minutes))
+    end
+  end
+
+  describe "perform/1 when testing backfill_shorts_data" do
+    test "sets short_form_content to true for media items with shorts in the URL" do
+      media_item = media_item_with_attachments(%{original_url: "https://example.com/shorts/123"})
+
+      refute media_item.short_form_content
+
+      perform_job(DataBackfillWorker, %{})
+
+      assert Repo.reload!(media_item).short_form_content
+    end
+
+    test "does not set short_form_content to true for media items without shorts in the URL" do
+      media_item = media_item_with_attachments(%{original_url: "https://example.com/longs/123"})
+
+      refute media_item.short_form_content
+
+      perform_job(DataBackfillWorker, %{})
+
+      refute Repo.reload!(media_item).short_form_content
+    end
+  end
+end


### PR DESCRIPTION
## What's new?

- Adds new worker for backfilling local data. Useful for ensuring existing data conforms to future schema changes
  - As the first change, this worker updates `short_form_content` for media items based on the `original_url`. This is to let existing shorts work with the new short detection logic in #59 

## What's changed?

- Updates existing startup task to kick off this new worker

## What's fixed?

N/A

## Any other comments?

N/A
