### PR TITLE
[Bugfix] Update check origin in release environment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,8 @@ config :pinchflat,
 # Configures the endpoint
 config :pinchflat, PinchflatWeb.Endpoint,
   url: [host: "localhost", port: 8945],
+  # NOTE: this must be updated if ever deployed traditionally (ie: not self-hosted)
+  check_origin: false,
   adapter: Phoenix.Endpoint.Cowboy2Adapter,
   render_errors: [
     formats: [html: PinchflatWeb.ErrorHTML, json: PinchflatWeb.ErrorJSON],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,7 +21,6 @@ config :pinchflat, PinchflatWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [port: 4008],
-  check_origin: false,
   code_reloader: true,
   debug_errors: true,
   secret_key_base: "QLKKs3ypkUgJ/fMnWZaIYqpMbnA4IlPVEm3tvezsblhFDv4b67rdp+AmTpAFFURK",


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Disables `check_origin` for websockets in release environment.
  - NOTE: this must be changed if you ever deploy to a traditional deployment environment (read: not selfhosted)

## Any other comments?

N/A
