### PR TITLE
Download cutoff date for sources

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,3 +1,4 @@
+import Ecto.Query, warn: false
 alias Pinchflat.Repo
 
 alias Pinchflat.Tasks.Task
@@ -33,6 +34,10 @@ defmodule IexHelpers do
 
   def video_url do
     "https://www.youtube.com/watch?v=bR52O78ZIUw"
+  end
+
+  def last_media_item do
+    Repo.one(from m in MediaItem, limit: 1)
   end
 
   def details(type) do

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -20,7 +20,7 @@ defmodule Pinchflat.Media.MediaItem do
     :livestream,
     :source_id,
     :short_form_content,
-    :uploaded_at,
+    :upload_date,
     # these fields are captured only on download
     :media_downloaded_at,
     :media_filepath,
@@ -36,7 +36,7 @@ defmodule Pinchflat.Media.MediaItem do
     livestream
     media_id
     source_id
-    uploaded_at
+    upload_date
     short_form_content
     )a
 
@@ -48,7 +48,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :livestream, :boolean, default: false
     field :short_form_content, :boolean, default: false
     field :media_downloaded_at, :utc_datetime
-    field :uploaded_at, :utc_datetime
+    field :upload_date, :date
 
     field :media_filepath, :string
     field :media_size_bytes, :integer

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -20,6 +20,7 @@ defmodule Pinchflat.Media.MediaItem do
     :livestream,
     :source_id,
     :short_form_content,
+    :uploaded_at,
     # these fields are captured only on download
     :media_downloaded_at,
     :media_filepath,
@@ -28,7 +29,16 @@ defmodule Pinchflat.Media.MediaItem do
     :thumbnail_filepath,
     :metadata_filepath
   ]
-  @required_fields ~w(title original_url livestream media_id source_id short_form_content)a
+  # Pretty much all the fields captured at index are required.
+  @required_fields ~w(
+    title
+    original_url
+    livestream
+    media_id
+    source_id
+    uploaded_at
+    short_form_content
+    )a
 
   schema "media_items" do
     field :title, :string
@@ -38,6 +48,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :livestream, :boolean, default: false
     field :short_form_content, :boolean, default: false
     field :media_downloaded_at, :utc_datetime
+    field :uploaded_at, :utc_datetime
 
     field :media_filepath, :string
     field :media_size_bytes, :integer

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -21,6 +21,7 @@ defmodule Pinchflat.Sources.Source do
     download_media
     last_indexed_at
     original_url
+    download_cutoff_date
     media_profile_id
   )a
 
@@ -45,8 +46,8 @@ defmodule Pinchflat.Sources.Source do
     field :fast_index, :boolean, default: false
     field :download_media, :boolean, default: true
     field :last_indexed_at, :utc_datetime
-    # This should only be used for user reference going forward
-    # as the collection_id should be used for all API calls
+    # Only download media items that were published after this date
+    field :download_cutoff_date, :date
     field :original_url, :string
 
     belongs_to :media_profile, MediaProfile

--- a/lib/pinchflat/tasks/source_tasks.ex
+++ b/lib/pinchflat/tasks/source_tasks.ex
@@ -96,12 +96,10 @@ defmodule Pinchflat.Tasks.SourceTasks do
   job run. This should ensure that any stragglers are caught if, for some reason, they
   weren't enqueued or somehow got de-queued.
 
-  Since indexing returns all media data EVERY TIME, we rely on the unique index of the
-  media_id to prevent duplicates. Due to both the file follower and the fact that future
-  indexing will index a lot of existing data, this method will MOSTLY return error
-  changesets (from the unique index violation) and not media items. This is intended.
+  Since indexing returns all media data EVERY TIME, we that that opportunity to update
+  indexing metadata for media items that have already been created.
 
-  Returns [%MediaItem{}, ...] | [%Ecto.Changeset{}, ...]
+  Returns [%MediaItem{}, ...]
   """
   def index_and_enqueue_download_for_media_items(%Source{} = source) do
     # See the method definition below for more info on how file watchers work

--- a/lib/pinchflat/yt_dlp/backend/media.ex
+++ b/lib/pinchflat/yt_dlp/backend/media.ex
@@ -9,7 +9,8 @@ defmodule Pinchflat.YtDlp.Backend.Media do
     :description,
     :original_url,
     :livestream,
-    :short_form_content
+    :short_form_content,
+    :upload_date
   ]
 
   defstruct [
@@ -18,7 +19,8 @@ defmodule Pinchflat.YtDlp.Backend.Media do
     :description,
     :original_url,
     :livestream,
-    :short_form_content
+    :short_form_content,
+    :upload_date
   ]
 
   alias __MODULE__
@@ -67,7 +69,7 @@ defmodule Pinchflat.YtDlp.Backend.Media do
   Returns the output template for yt-dlp's indexing command.
   """
   def indexing_output_template do
-    "%(.{id,title,was_live,webpage_url,description,aspect_ratio,duration})j"
+    "%(.{id,title,was_live,webpage_url,description,aspect_ratio,duration,upload_date})j"
   end
 
   @doc """
@@ -83,7 +85,8 @@ defmodule Pinchflat.YtDlp.Backend.Media do
       description: response["description"],
       original_url: response["webpage_url"],
       livestream: response["was_live"],
-      short_form_content: short_form_content?(response)
+      short_form_content: short_form_content?(response),
+      upload_date: parse_upload_date(response["upload_date"])
     }
   end
 
@@ -98,6 +101,12 @@ defmodule Pinchflat.YtDlp.Backend.Media do
       # based on a gut feeling and may need to be tweaked.
       response["duration"] <= 60 && response["aspect_ratio"] < 0.8
     end
+  end
+
+  defp parse_upload_date(upload_date) do
+    <<year::binary-size(4)>> <> <<month::binary-size(2)>> <> <<day::binary-size(2)>> = upload_date
+
+    Date.from_iso8601!("#{year}-#{month}-#{day}")
   end
 
   defp backend_runner do

--- a/lib/pinchflat_web/components/core_components.ex
+++ b/lib/pinchflat_web/components/core_components.ex
@@ -598,9 +598,14 @@ defmodule PinchflatWeb.CoreComponents do
   def list_items_from_map(assigns) do
     attrs =
       Enum.filter(assigns.map, fn
-        {_, %{__struct__: _}} -> false
-        {_, [%{__meta__: _} | _]} -> false
-        _ -> true
+        {_, %{__struct__: s}} when s not in [Date, DateTime] ->
+          false
+
+        {_, [%{__meta__: _} | _]} ->
+          false
+
+        _ ->
+          true
       end)
 
     assigns = assign(assigns, iterable_attributes: attrs)

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -57,6 +57,14 @@
     help="Unchecking still indexes media but it won't be downloaded until you enable this option"
   />
 
+  <.input
+    field={f[:download_cutoff_date]}
+    type="text"
+    label="Download Cutoff Date"
+    placeholder="YYYY-MM-DD"
+    help="Only download media uploaded after this date. Leave blank to download all media. Must be in YYYY-MM-DD format"
+  />
+
   <.button class="my-10 sm:mb-7.5 w-full sm:w-auto">Save Source</.button>
 
   <div class="rounded-sm dark:bg-meta-4 p-4 md:p-6 mb-5">

--- a/priv/repo/migrations/20240310230713_add_uploaded_at_to_media_items.exs
+++ b/priv/repo/migrations/20240310230713_add_uploaded_at_to_media_items.exs
@@ -1,0 +1,11 @@
+defmodule Pinchflat.Repo.Migrations.AddUploadedAtToMediaItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_items) do
+      # Setting default to unix epoch so I can enforce not null BUT also easily
+      # identify records that were created before this column was added
+      add :uploaded_at, :utc_datetime, default: "1970-01-01T00:00:00", null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240310230713_add_uploaded_at_to_media_items.exs
+++ b/priv/repo/migrations/20240310230713_add_uploaded_at_to_media_items.exs
@@ -4,8 +4,9 @@ defmodule Pinchflat.Repo.Migrations.AddUploadedAtToMediaItems do
   def change do
     alter table(:media_items) do
       # Setting default to unix epoch so I can enforce not null BUT also easily
-      # identify records that were created before this column was added
-      add :uploaded_at, :utc_datetime, default: "1970-01-01T00:00:00", null: false
+      # identify records that were created before this column was added.
+      # Not a DateTime because yt-dlp only returns the date
+      add :upload_date, :date, default: "1970-01-01", null: false
     end
   end
 end

--- a/priv/repo/migrations/20240311033214_add_download_cutoff_date_to_sources.exs
+++ b/priv/repo/migrations/20240311033214_add_download_cutoff_date_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddDownloadCutoffDateToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :download_cutoff_date, :date
+    end
+  end
+end

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -378,6 +378,7 @@ defmodule Pinchflat.MediaTest do
       }
 
       assert {:ok, %MediaItem{} = media_item} = Media.create_media_item(valid_attrs)
+
       assert media_item.title == valid_attrs.title
       assert media_item.media_id == valid_attrs.media_id
       assert media_item.media_filepath == valid_attrs.media_filepath
@@ -398,11 +399,29 @@ defmodule Pinchflat.MediaTest do
         |> YtDlpMedia.response_to_struct()
 
       assert {:ok, %MediaItem{} = media_item} = Media.create_media_item_from_backend_attrs(source, media_attrs)
+
       assert media_item.source_id == source.id
       assert media_item.title == media_attrs.title
       assert media_item.media_id == media_attrs.media_id
       assert media_item.original_url == media_attrs.original_url
       assert media_item.description == media_attrs.description
+    end
+
+    test "updates the media item if it already exists" do
+      source = source_fixture()
+
+      media_attrs =
+        media_attributes_return_fixture()
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
+
+      different_attrs = %YtDlpMedia{media_attrs | title: "Different title"}
+
+      assert {:ok, %MediaItem{} = media_item_1} = Media.create_media_item_from_backend_attrs(source, media_attrs)
+      assert {:ok, %MediaItem{} = media_item_2} = Media.create_media_item_from_backend_attrs(source, different_attrs)
+
+      assert media_item_1.id == media_item_2.id
+      assert media_item_2.title == different_attrs.title
     end
   end
 

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -373,7 +373,8 @@ defmodule Pinchflat.MediaTest do
         title: Faker.Commerce.product_name(),
         media_filepath: "/video/#{Faker.File.file_name(:video)}",
         source_id: source_fixture().id,
-        original_url: "https://www.youtube.com/channel/#{Faker.String.base64(12)}"
+        original_url: "https://www.youtube.com/channel/#{Faker.String.base64(12)}",
+        upload_date: Date.utc_today()
       }
 
       assert {:ok, %MediaItem{} = media_item} = Media.create_media_item(valid_attrs)

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -115,6 +115,12 @@ defmodule Pinchflat.SourcesTest do
       assert {:error, %Ecto.Changeset{}} = Sources.create_source(@invalid_source_attrs)
     end
 
+    test "creation with invalid data fails fast and does not call the runner" do
+      expect(YtDlpRunnerMock, :run, 0, &channel_mock/3)
+
+      assert {:error, %Ecto.Changeset{}} = Sources.create_source(@invalid_source_attrs)
+    end
+
     test "creation enforces uniqueness of collection_id scoped to the media_profile" do
       expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot ->
         {:ok,
@@ -223,6 +229,14 @@ defmodule Pinchflat.SourcesTest do
 
       assert {:ok, %Source{} = source} = Sources.update_source(source, update_attrs)
       assert source.collection_name == "some updated name"
+    end
+
+    test "updates with invalid data fails fast and does not call the runner" do
+      expect(YtDlpRunnerMock, :run, 0, &channel_mock/3)
+
+      source = source_fixture()
+
+      assert {:error, %Ecto.Changeset{}} = Sources.update_source(source, @invalid_source_attrs)
     end
 
     test "updating the original_url will re-fetch the source details for channels" do
@@ -430,7 +444,7 @@ defmodule Pinchflat.SourcesTest do
     end
   end
 
-  describe "change_source/2" do
+  describe "change_source/3" do
     test "it returns a changeset" do
       source = source_fixture()
 

--- a/test/pinchflat/tasks/media_items_tasks_test.exs
+++ b/test/pinchflat/tasks/media_items_tasks_test.exs
@@ -88,7 +88,8 @@ defmodule Pinchflat.Tasks.MediaItemTasksTest do
             was_live: true,
             description: "desc2",
             aspect_ratio: 1.67,
-            duration: 345.67
+            duration: 345.67,
+            upload_date: "20210101"
           })
 
         {:ok, output}

--- a/test/pinchflat/tasks/media_items_tasks_test.exs
+++ b/test/pinchflat/tasks/media_items_tasks_test.exs
@@ -49,10 +49,11 @@ defmodule Pinchflat.Tasks.MediaItemTasksTest do
     end
 
     test "won't duplicate media_items based on media_id and source", %{source: source} do
-      assert {:ok, _} = MediaItemTasks.index_and_enqueue_download_for_media_item(source, @media_url)
-      assert {:error, _} = MediaItemTasks.index_and_enqueue_download_for_media_item(source, @media_url)
+      assert {:ok, mi_1} = MediaItemTasks.index_and_enqueue_download_for_media_item(source, @media_url)
+      assert {:ok, mi_2} = MediaItemTasks.index_and_enqueue_download_for_media_item(source, @media_url)
 
       assert Repo.aggregate(MediaItem, :count) == 1
+      assert mi_1.id == mi_2.id
     end
 
     test "enqueues a download job", %{source: source} do

--- a/test/pinchflat/tasks/source_tasks_test.exs
+++ b/test/pinchflat/tasks/source_tasks_test.exs
@@ -168,12 +168,14 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
                Enum.map(media_items_other_source, & &1.media_id)
     end
 
-    test "it returns a list of media_items or changesets", %{source: source} do
+    test "it returns a list of media_items", %{source: source} do
       first_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
       duplicate_run = SourceTasks.index_and_enqueue_download_for_media_items(source)
 
-      assert Enum.all?(first_run, fn %MediaItem{} -> true end)
-      assert Enum.all?(duplicate_run, fn %Ecto.Changeset{} -> true end)
+      first_ids = Enum.map(first_run, & &1.id)
+      duplicate_ids = Enum.map(duplicate_run, & &1.id)
+
+      assert first_ids == duplicate_ids
     end
 
     test "it updates the source's last_indexed_at field", %{source: source} do

--- a/test/pinchflat/tasks/source_tasks_test.exs
+++ b/test/pinchflat/tasks/source_tasks_test.exs
@@ -282,7 +282,8 @@ defmodule Pinchflat.Tasks.SourceTasksTest do
             was_live: true,
             description: "desc2",
             aspect_ratio: 1.67,
-            duration: 345.67
+            duration: 345.67,
+            upload_date: "20210101"
           })
 
         File.write(filepath, contents)

--- a/test/pinchflat/yt_dlp/backend/media_test.exs
+++ b/test/pinchflat/yt_dlp/backend/media_test.exs
@@ -79,7 +79,7 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
 
   describe "indexing_output_template/0" do
     test "contains all the greatest hits" do
-      assert "%(.{id,title,was_live,webpage_url,description,aspect_ratio,duration})j" ==
+      assert "%(.{id,title,was_live,webpage_url,description,aspect_ratio,duration,upload_date})j" ==
                Media.indexing_output_template()
     end
   end
@@ -93,7 +93,8 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
         "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "was_live" => false,
         "aspect_ratio" => 1.0,
-        "duration" => 60
+        "duration" => 60,
+        "upload_date" => "20210101"
       }
 
       assert %Media{
@@ -102,15 +103,17 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
                description: "I'm not sure what I expected.",
                original_url: "https://www.youtube.com/watch?v=TiZPUDkDYbk",
                livestream: false,
-               short_form_content: false
-             } = Media.response_to_struct(response)
+               short_form_content: false,
+               upload_date: Date.from_iso8601!("2021-01-01")
+             } == Media.response_to_struct(response)
     end
 
     test "sets short_form_content to true if the URL contains /shorts/" do
       response = %{
         "webpage_url" => "https://www.youtube.com/shorts/TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
-        "duration" => 61
+        "duration" => 61,
+        "upload_date" => "20210101"
       }
 
       assert %Media{short_form_content: true} = Media.response_to_struct(response)
@@ -120,7 +123,8 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
       response = %{
         "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 0.5,
-        "duration" => 59
+        "duration" => 59,
+        "upload_date" => "20210101"
       }
 
       assert %Media{short_form_content: true} = Media.response_to_struct(response)
@@ -130,7 +134,8 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
       response = %{
         "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
-        "duration" => 61
+        "duration" => 61,
+        "upload_date" => "20210101"
       }
 
       assert %Media{short_form_content: false} = Media.response_to_struct(response)

--- a/test/pinchflat/yt_dlp/backend/media_test.exs
+++ b/test/pinchflat/yt_dlp/backend/media_test.exs
@@ -140,5 +140,18 @@ defmodule Pinchflat.YtDlp.Backend.MediaTest do
 
       assert %Media{short_form_content: false} = Media.response_to_struct(response)
     end
+
+    test "parses the upload date" do
+      response = %{
+        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "aspect_ratio" => 1.0,
+        "duration" => 61,
+        "upload_date" => "20210101"
+      }
+
+      expected_date = Date.from_iso8601!("2021-01-01")
+
+      assert %Media{upload_date: ^expected_date} = Media.response_to_struct(response)
+    end
   end
 end

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -21,7 +21,8 @@ defmodule Pinchflat.MediaFixtures do
         livestream: false,
         short_form_content: false,
         media_filepath: "/video/#{Faker.File.file_name(:video)}",
-        source_id: SourcesFixtures.source_fixture().id
+        source_id: SourcesFixtures.source_fixture().id,
+        upload_date: DateTime.utc_now()
       })
       |> Pinchflat.Media.create_media_item()
 
@@ -75,7 +76,8 @@ defmodule Pinchflat.MediaFixtures do
       was_live: false,
       description: "desc1",
       aspect_ratio: 1.67,
-      duration: 123.45
+      duration: 123.45,
+      upload_date: "20210101"
     }
 
     Phoenix.json_library().encode!(media_attributes)

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -39,7 +39,8 @@ defmodule Pinchflat.SourcesFixtures do
         was_live: false,
         description: "desc1",
         aspect_ratio: 1.67,
-        duration: 12.34
+        duration: 12.34,
+        upload_date: "20210101"
       },
       %{
         id: "video2",
@@ -48,7 +49,8 @@ defmodule Pinchflat.SourcesFixtures do
         was_live: true,
         description: "desc2",
         aspect_ratio: 1.67,
-        duration: 345.67
+        duration: 345.67,
+        upload_date: "20220202"
       },
       %{
         id: "video3",
@@ -57,7 +59,8 @@ defmodule Pinchflat.SourcesFixtures do
         was_live: false,
         description: "desc3",
         aspect_ratio: 1.0,
-        duration: 678.90
+        duration: 678.90,
+        upload_date: "20230303"
       }
     ]
 

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -15,15 +15,19 @@ defmodule Pinchflat.SourcesFixtures do
     {:ok, source} =
       %Source{}
       |> Source.changeset(
-        Enum.into(attrs, %{
-          collection_name: "Source ##{:rand.uniform(1_000_000)}",
-          collection_id: Base.encode16(:crypto.hash(:md5, "#{:rand.uniform(1_000_000)}")),
-          collection_type: "channel",
-          custom_name: "Cool and good internal name!",
-          original_url: "https://www.youtube.com/channel/#{Faker.String.base64(12)}",
-          media_profile_id: ProfilesFixtures.media_profile_fixture().id,
-          index_frequency_minutes: 60
-        })
+        Enum.into(
+          attrs,
+          %{
+            collection_name: "Source ##{:rand.uniform(1_000_000)}",
+            collection_id: Base.encode16(:crypto.hash(:md5, "#{:rand.uniform(1_000_000)}")),
+            collection_type: "channel",
+            custom_name: "Cool and good internal name!",
+            original_url: "https://www.youtube.com/channel/#{Faker.String.base64(12)}",
+            media_profile_id: ProfilesFixtures.media_profile_fixture().id,
+            index_frequency_minutes: 60
+          }
+        ),
+        :pre_insert
       )
       |> Repo.insert()
 

--- a/test/support/testing_helper_methods.ex
+++ b/test/support/testing_helper_methods.ex
@@ -11,6 +11,14 @@ defmodule Pinchflat.TestingHelperMethods do
     DateTime.add(now(), offset, :minute)
   end
 
+  def now_minus(offset, unit) when unit in [:minute, :minutes] do
+    DateTime.add(now(), -offset, :minute)
+  end
+
+  def now_minus(offset, unit) when unit in [:day, :days] do
+    DateTime.add(now(), -offset, :day)
+  end
+
   def assert_changed(checker_fun, action_fn) do
     before_res = checker_fun.()
     action_fn.()


### PR DESCRIPTION
## What's new?

- Adds ability to specify a download cutoff date where only media from after that date will be downloaded. Related to #60 
- Adds `upload_date` to media items

## What's changed?

- Updates media item creation during indexing to have `ON CONFLICT UPDATE` logic rather than failing the insert

## What's fixed?

N/A

## Any other comments?

N/A
