### PR TITLE
Upgrade to Elixir 1.16.2

### DIFF
--- a/.check.exs
+++ b/.check.exs
@@ -9,18 +9,15 @@
   fix: true,
 
   ## don't retry automatically even if last run resulted in failures
-  # retry: false,
+  retry: false,
 
   ## list of tools (see `mix check` docs for a list of default curated tools)
   tools: [
     {:compiler, env: %{"MIX_ENV" => "test"}},
     {:formatter, env: %{"MIX_ENV" => "test"}},
     {:sobelow, "mix sobelow --config"},
-    # TODO: delete these and replace them with builtin ex_unit and formatter tools
-    # once Elixir 1.16.2 is released (see: https://github.com/karolsluszniak/ex_check/issues/41#issuecomment-1921390413)
-    {:elixir_tests, "mix test"},
-    {:elixir_formatting, "mix format --check-formatted", fix: "mix format"},
-    {:prettier_formatting, "yarn run prettier . --check", fix: "yarn run prettier . --write"}
+    {:prettier_formatting, "yarn run prettier . --check", fix: "yarn run prettier . --write"},
+    {:npm_test, false}
 
     ## curated tools may be disabled (e.g. the check for compilation warnings)
     # {:compiler, false},

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,9 +1,13 @@
-# Extend from the official Elixir image.
-FROM elixir:latest
+ARG ELIXIR_VERSION=1.16.2
+ARG OTP_VERSION=26.2.2
+ARG DEBIAN_VERSION=bookworm-20240130
+ARG DEV_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+
+FROM ${DEV_IMAGE}
 
 # Install debian packages
 RUN apt-get update -qq
-RUN apt-get install -y inotify-tools ffmpeg \
+RUN apt-get install -y inotify-tools ffmpeg curl git openssh-client \
   python3 python3-pip python3-setuptools python3-wheel python3-dev
 
 # Install nodejs
@@ -28,6 +32,7 @@ COPY . ./
 RUN chmod +x ./docker-run.dev.sh
 
 # Install Elixir deps
+# RUN mix archive.install github hexpm/hex branch latest
 RUN mix deps.get
 # Gives us iex shell history
 ENV ERL_AFLAGS="-kernel shell_history enabled"

--- a/ideas.md
+++ b/ideas.md
@@ -2,5 +2,3 @@
   - Use a UUID for the media database ID (or at least alongside it)
 - Look into this and its recommended plugins https://hexdocs.pm/ex_check/readme.html
 - Add output template option for the source's friendly name
-- TODO: Install Elixir 1.16.2 when available to fix bug with `ex_check` https://github.com/karolsluszniak/ex_check/issues/41#issuecomment-1921390413
-  - delete `{:elixir_tests, "mix test"}` and formatting check


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Upgrade to Elixir 1.16.2
- Updated selfhosted Dockerfile:
  - Installs `yt-dlp` using a binary instead
  - Removes password from root user. See comments for rationale

## What's fixed?

- The upgrade allowed me to remove some workarounds from the `mix check` command

## Any other comments?

N/A
