### PR TITLE
Onboarding improvements

### DIFF
--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -30,7 +30,7 @@ defmodule Pinchflat.Profiles.MediaProfile do
     field :name, :string
 
     field :output_path_template, :string,
-      default: "/{{ source_custom_name }}/{{ title }}/{{ title }} [{{ id }}].{{ ext }}"
+      default: "/{{ source_custom_name }}/{{ upload_yyyy_mm_dd }} {{ title }}/{{ title }} [{{ id }}].{{ ext }}"
 
     field :download_subs, :boolean, default: true
     field :download_auto_subs, :boolean, default: true

--- a/lib/pinchflat/profiles/output_path_builder.ex
+++ b/lib/pinchflat/profiles/output_path_builder.ex
@@ -39,7 +39,8 @@ defmodule Pinchflat.Profiles.OutputPathBuilder do
       # Individual parts of the upload date
       "upload_year" => "%(upload_date>%Y)S",
       "upload_month" => "%(upload_date>%m)S",
-      "upload_day" => "%(upload_date>%d)S"
+      "upload_day" => "%(upload_date>%d)S",
+      "upload_yyyy_mm_dd" => "%(upload_date>%Y)S-%(upload_date>%m)S-%(upload_date>%d)S"
     }
   end
 end

--- a/lib/pinchflat_web/components/layouts/root.html.heex
+++ b/lib/pinchflat_web/components/layouts/root.html.heex
@@ -13,13 +13,17 @@
     </script>
   </head>
   <body
-    x-data={"{ sidebarVisible: false, proEnabled: #{Settings.get!(:pro_enabled)} }"}
+    x-data={"{ 
+      sidebarVisible: false,
+      proEnabled: #{Settings.get!(:pro_enabled)},
+      onboarding: #{Settings.get!(:onboarding)}
+    }"}
     class="dark text-bodydark bg-boxdark-2"
   >
     <%= @inner_content %>
 
     <.donate_modal conn={@conn} />
-    <template x-if="!proEnabled">
+    <template x-if="!proEnabled && !onboarding">
       <.upgrade_modal conn={@conn} />
     </template>
   </body>

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -35,6 +35,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       upload_day: nil,
       upload_month: nil,
       upload_year: nil,
+      upload_yyyy_mm_dd: "the upload date in the format YYYY-MM-DD",
       source_custom_name: "the name of the sources that use this profile",
       source_collection_type: "the collection type of the sources that use this profile. Either 'channel' or 'playlist'"
     }

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -19,7 +19,7 @@
     type="text"
     inputclass="font-mono"
     label="Output path template"
-    help="Must end with .{{ ext }}. See below for more details. I promise the default is good for most cases (required)"
+    help="Must end with .{{ ext }}. See below for more details. The default is good for most cases (required)"
   />
 
   <h3 class="mt-8 text-2xl text-black dark:text-white">

--- a/lib/pinchflat_web/controllers/pages/page_controller.ex
+++ b/lib/pinchflat_web/controllers/pages/page_controller.ex
@@ -8,38 +8,34 @@ defmodule PinchflatWeb.Pages.PageController do
   alias Pinchflat.Profiles.MediaProfile
 
   def home(conn, params) do
-    force_onboarding = params["onboarding"]
-    media_profiles_exist = Repo.exists?(MediaProfile)
-    sources_exist = Repo.exists?(Source)
+    done_onboarding = params["onboarding"] == "0"
+    force_onboarding = params["onboarding"] == "1"
 
-    if !force_onboarding && media_profiles_exist && sources_exist do
-      render_home_page(conn)
+    if done_onboarding, do: Settings.set!(:onboarding, false)
+
+    if force_onboarding || Settings.get!(:onboarding) do
+      render_onboarding_page(conn)
     else
-      render_onboarding_page(conn, media_profiles_exist, sources_exist)
+      render_home_page(conn)
     end
   end
 
   defp render_home_page(conn) do
-    Settings.set!(:onboarding, false)
-    media_profile_count = Repo.aggregate(MediaProfile, :count, :id)
-    source_count = Repo.aggregate(Source, :count, :id)
-    media_item_count = Repo.aggregate(MediaItem, :count, :id)
-
     conn
     |> render(:home,
-      media_profile_count: media_profile_count,
-      source_count: source_count,
-      media_item_count: media_item_count
+      media_profile_count: Repo.aggregate(MediaProfile, :count, :id),
+      source_count: Repo.aggregate(Source, :count, :id),
+      media_item_count: Repo.aggregate(MediaItem, :count, :id)
     )
   end
 
-  defp render_onboarding_page(conn, media_profiles_exist, sources_exist) do
+  defp render_onboarding_page(conn) do
     Settings.set!(:onboarding, true)
 
     conn
     |> render(:onboarding_checklist,
-      media_profiles_exist: media_profiles_exist,
-      sources_exist: sources_exist,
+      media_profiles_exist: Repo.exists?(MediaProfile),
+      sources_exist: Repo.exists?(Source),
       layout: {Layouts, :onboarding}
     )
   end

--- a/lib/pinchflat_web/controllers/pages/page_html/onboarding_checklist.html.heex
+++ b/lib/pinchflat_web/controllers/pages/page_html/onboarding_checklist.html.heex
@@ -39,7 +39,7 @@
         </p>
         <p class="text-md text-bodydark">Feel free to add more Media Profiles or Sources in the meantime!</p>
         <div class="mt-8">
-          <.link href={~p"/"}>
+          <.link href={~p"/?onboarding=0"}>
             <.button color="bg-primary" rounding="rounded-full" disabled={not @sources_exist}>
               Let's Go <span class="font-bold mx-2">🚀</span>
             </.button>

--- a/test/pinchflat_web/controllers/page_controller_test.exs
+++ b/test/pinchflat_web/controllers/page_controller_test.exs
@@ -1,51 +1,31 @@
 defmodule PinchflatWeb.PageControllerTest do
   use PinchflatWeb.ConnCase
 
-  import Pinchflat.ProfilesFixtures
-  import Pinchflat.SourcesFixtures
-
   alias Pinchflat.Settings
 
   describe "GET / when testing onboarding" do
-    test "sets the onboarding session to true when onboarding", %{conn: conn} do
+    test "sets the onboarding setting to true when onboarding", %{conn: conn} do
       _conn = get(conn, ~p"/")
       assert Settings.get!(:onboarding)
     end
 
-    test "displays the onboarding page when no media profiles exist", %{conn: conn} do
-      conn = get(conn, ~p"/")
-      assert html_response(conn, 200) =~ "Welcome to Pinchflat"
-    end
-
-    test "displays the onboarding page when no sources exist", %{conn: conn} do
-      _ = media_profile_fixture()
-
-      conn = get(conn, ~p"/")
-      assert html_response(conn, 200) =~ "Welcome to Pinchflat"
-    end
-
     test "displays the onboarding page when onboarding is forced", %{conn: conn} do
-      _ = media_profile_fixture()
-      _ = source_fixture()
+      Settings.set!(:onboarding, false)
 
       conn = get(conn, ~p"/?onboarding=1")
       assert html_response(conn, 200) =~ "Welcome to Pinchflat"
     end
 
-    test "sets the onboarding session to false when not onboarding", %{conn: conn} do
+    test "sets the onboarding setting to false if you pass the corrent query param", %{conn: conn} do
       conn = get(conn, ~p"/")
       assert Settings.get!(:onboarding)
 
-      _ = media_profile_fixture()
-      _ = source_fixture()
-
-      _conn = get(conn, ~p"/")
+      _conn = get(conn, ~p"/?onboarding=0")
       refute Settings.get!(:onboarding)
     end
 
     test "displays the home page when not onboarding", %{conn: conn} do
-      _ = media_profile_fixture()
-      _ = source_fixture()
+      Settings.set!(:onboarding, false)
 
       conn = get(conn, ~p"/")
       assert html_response(conn, 200) =~ "MENU"


### PR DESCRIPTION
## What's new?

- Adds a `{{ upload_yyyy_mm_dd }}` output path helper to return the `YYYY-MM-DD` upload date

## What's changed?

- Disabled "pro" modal during onboarding. No need to overwhelm
- Improved the way onboarding tracks onboarding status so it doesn't re-run onboarding if you delete all your profiles/sources
- Updates the default media profile output template to include `{{ upload_yyyy_mm_dd }}`

## What's fixed?

N/A

## Any other comments?

N/A
