### PR TITLE
[Bugfix] Fixes issue with grabbing source/media details when first video is a premier

### DIFF
--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -54,7 +54,10 @@ defmodule Pinchflat.YtDlp.MediaCollection do
   Returns {:ok, map()} | {:error, any, ...}.
   """
   def get_source_details(source_url) do
-    opts = [:simulate, :skip_download, playlist_end: 1]
+    # `ignore_no_formats_error` is necessary because yt-dlp will error out if
+    # the first video has not released yet (ie: is a premier). We don't care about
+    # available formats since we're just getting the source details
+    opts = [:simulate, :skip_download, :ignore_no_formats_error, playlist_end: 1]
     output_template = "%(.{channel,channel_id,playlist_id,playlist_title})j"
 
     with {:ok, output} <- backend_runner().run(source_url, opts, output_template),

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -22,7 +22,10 @@ defmodule Pinchflat.YtDlp.MediaCollection do
   """
   def get_media_attributes_for_collection(url, addl_opts \\ []) do
     runner = Application.get_env(:pinchflat, :yt_dlp_runner)
-    command_opts = [:simulate, :skip_download]
+    # `ignore_no_formats_error` is necessary because yt-dlp will error out if
+    # the first video has not released yet (ie: is a premier). We don't care about
+    # available formats since we're just getting the media details
+    command_opts = [:simulate, :skip_download, :ignore_no_formats_error]
     output_template = YtDlpMedia.indexing_output_template()
     output_filepath = FilesystemHelpers.generate_metadata_tmpfile(:json)
     file_listener_handler = Keyword.get(addl_opts, :file_listener_handler, false)

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -87,7 +87,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
     test "it passes the expected args to the backend runner" do
       expect(YtDlpRunnerMock, :run, fn @channel_url, opts, ot ->
-        assert opts == [:simulate, :skip_download, playlist_end: 1]
+        assert opts == [:simulate, :skip_download, :ignore_no_formats_error, playlist_end: 1]
         assert ot == "%(.{channel,channel_id,playlist_id,playlist_title})j"
 
         {:ok, "{}"}

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -22,7 +22,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
     test "it passes the expected default args" do
       expect(YtDlpRunnerMock, :run, fn _url, opts, ot, _addl_opts ->
-        assert opts == [:simulate, :skip_download]
+        assert opts == [:simulate, :skip_download, :ignore_no_formats_error]
         assert ot == Media.indexing_output_template()
 
         {:ok, ""}


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Fixes issue where `yt-dlp` would return a "No formats error" if the first video in a collection was set to premier in the future. Now, premiers are ignored (but will be downloaded at the next index once they've available). Brought to my attention by a Reddit comment

## Any other comments?

N/A
