### PR TITLE
Add input validation to help with cutoff date usage

### DIFF
--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -62,6 +62,9 @@
     type="text"
     label="Download Cutoff Date"
     placeholder="YYYY-MM-DD"
+    maxlength="10"
+    pattern="((?:19|20)[0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+    title="YYYY-MM-DD"
     help="Only download media uploaded after this date. Leave blank to download all media. Must be in YYYY-MM-DD format"
   />
 


### PR DESCRIPTION
## What's new?

- Adds input validation to make sure the cutoff date is a string in the `YYYY-MM-DD` format with a max of 10 chars. Should help with some bug reports I've seen that stem from users putting in the date in the wrong format.
  - Ensures year is in 1900-2099, month is in 01-12, and day is in 01-31. Does no validation for number of days in a month

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A
