### PR TITLE
[Bugfix] Fix reddit bugs v2

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -66,7 +66,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
           acc ++ [:write_thumbnail, convert_thumbnail: "jpg"]
 
         {:embed_thumbnail, true} ->
-          acc ++ [:embed_thumbnail]
+          acc ++ [:embed_thumbnail, convert_thumbnail: "jpg"]
 
         _ ->
           acc

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -41,6 +41,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   Given a media source, creates (indexes) the media by creating media_items for each
   media ID in the source. Afterward, kicks off a download task for each pending media
   item belonging to the source. You can't tell me the method name isn't descriptive!
+  Returns a list of media items or changesets (if the media item couldn't be created).
 
   Indexing is slow and usually returns a list of all media data at once for record creation.
   To help with this, we use a file follower to watch the file that yt-dlp writes to
@@ -56,7 +57,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   Since indexing returns all media data EVERY TIME, we that that opportunity to update
   indexing metadata for media items that have already been created.
 
-  Returns [%MediaItem{}, ...]
+  Returns [%MediaItem{} | %Ecto.Changeset{}]
   """
   def index_and_enqueue_download_for_media_items(%Source{} = source) do
     # See the method definition below for more info on how file watchers work

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -85,8 +85,8 @@ defmodule Pinchflat.YtDlp.Media do
       description: response["description"],
       original_url: response["webpage_url"],
       livestream: response["was_live"],
-      short_form_content: short_form_content?(response),
-      upload_date: parse_upload_date(response["upload_date"])
+      short_form_content: response["webpage_url"] && short_form_content?(response),
+      upload_date: response["upload_date"] && parse_upload_date(response["upload_date"])
     }
   end
 
@@ -99,6 +99,9 @@ defmodule Pinchflat.YtDlp.Media do
       # WILL returns false positives, but it's a best-effort approach
       # that should work for most cases. The aspect_ratio check is
       # based on a gut feeling and may need to be tweaked.
+      #
+      # These don't fail if duration or aspect_ratio are missing
+      # due to Elixir's comparison semantics
       response["duration"] <= 60 && response["aspect_ratio"] < 0.8
     end
   end

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -141,6 +141,14 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert :embed_thumbnail in res
     end
 
+    test "convertes thumbnail to jpg when embed_thumbnail is true", %{media_item: media_item} do
+      media_item = update_media_profile_attribute(media_item, %{embed_thumbnail: true})
+
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item)
+
+      assert {:convert_thumbnail, "jpg"} in res
+    end
+
     test "doesn't include these options when not specified", %{media_item: media_item} do
       media_item = update_media_profile_attribute(media_item, %{embed_thumbnail: false, download_thumbnail: false})
 

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -141,6 +141,16 @@ defmodule Pinchflat.YtDlp.MediaTest do
       assert %Media{short_form_content: false} = Media.response_to_struct(response)
     end
 
+    test "doesn't blow up if short form content-related fields are missing" do
+      response = %{
+        "webpage_url" => nil,
+        "aspect_ratio" => nil,
+        "duration" => nil
+      }
+
+      assert %Media{short_form_content: nil} = Media.response_to_struct(response)
+    end
+
     test "parses the upload date" do
       response = %{
         "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
@@ -152,6 +162,17 @@ defmodule Pinchflat.YtDlp.MediaTest do
       expected_date = Date.from_iso8601!("2021-01-01")
 
       assert %Media{upload_date: ^expected_date} = Media.response_to_struct(response)
+    end
+
+    test "doesn't blow up if upload date is missing" do
+      response = %{
+        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "aspect_ratio" => 1.0,
+        "duration" => 61,
+        "upload_date" => nil
+      }
+
+      assert %Media{upload_date: nil} = Media.response_to_struct(response)
     end
   end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Ensures thumbnails are converted to `.jpg` when used for embedding

## What's fixed?

- Fixes bug where missing upload_date would cause indexing to fail and retry
  - Indexing would fail if a Media struct's `upload_date` could not be parsed. This could happen when there's a video on a playlist that's now unavailable ([example](https://www.youtube.com/playlist?list=PL0PwxJm2JWCRdZ41OofKKAVGTbuJ8lbnd))

## Any other comments?

N/A
