### PR TITLE
Append `-thumb` to thumbnails when downloading

### DIFF
--- a/lib/pinchflat/metadata/metadata_parser.ex
+++ b/lib/pinchflat/metadata/metadata_parser.ex
@@ -54,9 +54,22 @@ defmodule Pinchflat.Metadata.MetadataParser do
       |> Enum.reverse()
       |> Enum.find_value(fn attrs -> attrs["filepath"] end)
 
-    %{
-      thumbnail_filepath: thumbnail_filepath
-    }
+    if thumbnail_filepath do
+      # NOTE: whole ordeal needed due to a bug I found in yt-dlp
+      # https://github.com/yt-dlp/yt-dlp/issues/9445
+      # Can be reverted to remove this entire conditional once fixed
+      %{
+        thumbnail_filepath:
+          thumbnail_filepath
+          |> String.split(~r{\.}, include_captures: true)
+          |> List.insert_at(-3, "-thumb")
+          |> Enum.join()
+      }
+    else
+      %{
+        thumbnail_filepath: thumbnail_filepath
+      }
+    end
   end
 
   defp parse_infojson_metadata(metadata) do

--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -67,6 +67,12 @@ defmodule Pinchflat.Profiles.MediaProfile do
     media_profile
     |> cast(attrs, @allowed_fields)
     |> validate_required(@required_fields)
+    # Ensures it ends with `.{{ ext }}` or `.%(ext)s` or similar (with a little wiggle room)
+    |> validate_format(:output_path_template, ext_regex(), message: "must end with .{{ ext }}")
     |> unique_constraint(:name)
+  end
+
+  defp ext_regex do
+    ~r/\.({{ ?ext ?}}|%\( ?ext ?\)[sS])$/
   end
 end

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -125,7 +125,15 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert :write_thumbnail in res
     end
 
-    test "convertes thumbnail to jpg when download_thumbnail is true", %{media_item: media_item} do
+    test "appends -thumb to the thumbnail name when download_thumbnail is true", %{media_item: media_item} do
+      media_item = update_media_profile_attribute(media_item, %{download_thumbnail: true})
+
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item)
+
+      assert {:output, "thumbnail:/tmp/test/media/%(title)S-thumb.%(ext)s"} in res
+    end
+
+    test "converts thumbnail to jpg when download_thumbnail is true", %{media_item: media_item} do
       media_item = update_media_profile_attribute(media_item, %{download_thumbnail: true})
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)

--- a/test/pinchflat/metadata/metadata_parser_test.exs
+++ b/test/pinchflat/metadata/metadata_parser_test.exs
@@ -94,6 +94,15 @@ defmodule Pinchflat.Metadata.MetadataParserTest do
       assert String.ends_with?(result.thumbnail_filepath, ".webp")
     end
 
+    # NOTE: this can be removed once this bug is fixed
+    # https://github.com/yt-dlp/yt-dlp/issues/9445
+    # and the associated conditional in the parser is removed
+    test "automatically appends `-thumb` to the thumbnail filename", %{metadata: metadata} do
+      result = Parser.parse_for_media_item(metadata)
+
+      assert String.contains?(result.thumbnail_filepath, "-thumb.webp")
+    end
+
     test "doesn't freak out if the media has no thumbnails", %{metadata: metadata} do
       metadata = Map.put(metadata, "thumbnails", %{})
 

--- a/test/pinchflat_web/controllers/media_profile_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_profile_controller_test.exs
@@ -8,10 +8,10 @@ defmodule PinchflatWeb.MediaProfileControllerTest do
   alias Pinchflat.Repo
   alias Pinchflat.Settings
 
-  @create_attrs %{name: "some name", output_path_template: "some output_path_template"}
+  @create_attrs %{name: "some name", output_path_template: "output_template.{{ ext }}"}
   @update_attrs %{
     name: "some updated name",
-    output_path_template: "some updated output_path_template"
+    output_path_template: "new_output_template.{{ ext }}"
   }
   @invalid_attrs %{name: nil, output_path_template: nil}
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Downloaded thumbnails are now appended with `-thumb` to be better supported by media centre apps
  - NOTE: I'm pretty hesitant to base app decisions around the expectations other apps, but this one seemed like a good change across the board so it's now the default
  - NOTE: I found a bug in yt-dlp when working on this and I've made a report for it: https://github.com/yt-dlp/yt-dlp/issues/9445

## What's fixed?

N/A

## Any other comments?

N/A
