### PR TITLE
Squash all the commits from the other branch bc I broke things

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -48,7 +48,8 @@ config :pinchflat, Oban,
     media_indexing: 2,
     media_collection_indexing: 2,
     media_fetching: 2,
-    media_local_metadata: 8
+    local_metadata: 8,
+    remote_metadata: 4
   ]
 
 # Configures the mailer

--- a/lib/pinchflat/boot/data_backfill_worker.ex
+++ b/lib/pinchflat/boot/data_backfill_worker.ex
@@ -2,7 +2,7 @@ defmodule Pinchflat.Boot.DataBackfillWorker do
   @moduledoc false
 
   use Oban.Worker,
-    queue: :media_local_metadata,
+    queue: :local_metadata,
     unique: [period: :infinity, states: [:available, :scheduled, :retryable]],
     tags: ["media_item", "media_metadata", "local_metadata", "data_backfill"]
 

--- a/lib/pinchflat/filesystem/filesystem_data_worker.ex
+++ b/lib/pinchflat/filesystem/filesystem_data_worker.ex
@@ -2,7 +2,7 @@ defmodule Pinchflat.Filesystem.FilesystemDataWorker do
   @moduledoc false
 
   use Oban.Worker,
-    queue: :media_local_metadata,
+    queue: :local_metadata,
     tags: ["media_item", "media_metadata", "local_metadata"],
     max_attempts: 1
 
@@ -12,6 +12,10 @@ defmodule Pinchflat.Filesystem.FilesystemDataWorker do
   @impl Oban.Worker
   @doc """
   For a given media item, compute and save metadata about the file on-disk.
+
+  IDEA: does this have to be a standalone job? I originally split it out
+  so a failure here wouldn't cause a downloader job retry, but I can match
+  for failures so it doesn't retry.
 
   Returns :ok
   """

--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -144,6 +144,8 @@ defmodule Pinchflat.Media do
   @doc """
   Produces a flat list of the filesystem paths for a media_item's downloaded files
 
+  NOTE: this can almost certainly be made private
+
   Returns [binary()]
   """
   def media_filepaths(media_item) do
@@ -161,6 +163,8 @@ defmodule Pinchflat.Media do
   @doc """
   Produces a flat list of the filesystem paths for a media_item's metadata files.
   Returns an empty list if the media_item has no metadata.
+
+  NOTE: this can almost certainly be made private
 
   Returns [binary()] | []
   """
@@ -227,6 +231,7 @@ defmodule Pinchflat.Media do
   def delete_media_item(%MediaItem{} = media_item, opts \\ []) do
     delete_files = Keyword.get(opts, :delete_files, false)
 
+    # NOTE: this should delete metadata no matter what
     if delete_files do
       {:ok, _} = delete_all_attachments(media_item)
     end
@@ -242,6 +247,7 @@ defmodule Pinchflat.Media do
     MediaItem.changeset(media_item, attrs)
   end
 
+  # NOTE: refactor this
   defp delete_all_attachments(media_item) do
     media_item = Repo.preload(media_item, :metadata)
 

--- a/lib/pinchflat/metadata/source_metadata.ex
+++ b/lib/pinchflat/metadata/source_metadata.ex
@@ -1,0 +1,36 @@
+defmodule Pinchflat.Metadata.SourceMetadata do
+  @moduledoc """
+  The SourceMetadata schema.
+
+  Look. Don't @ me about Metadata vs. Metadatum. I'm very sensitive.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Pinchflat.Sources.Source
+
+  @allowed_fields ~w(metadata_filepath)a
+  @required_fields ~w(metadata_filepath)a
+
+  schema "source_metadata" do
+    field :metadata_filepath, :string
+
+    belongs_to :source, Source
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(source_metadata, attrs) do
+    source_metadata
+    |> cast(attrs, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint([:source_id])
+  end
+
+  @doc false
+  def filepath_attributes do
+    ~w(metadata_filepath)a
+  end
+end

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -1,0 +1,48 @@
+defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :remote_metadata,
+    tags: ["media_source", "source_metadata", "remote_metadata"],
+    max_attempts: 1
+
+  alias __MODULE__
+  alias Pinchflat.Repo
+  alias Pinchflat.Tasks
+  alias Pinchflat.Sources
+  alias Pinchflat.YtDlp.MediaCollection
+  alias Pinchflat.Metadata.MetadataFileHelpers
+
+  @doc """
+  Starts the source metadata storage worker and creates a task for the source.
+
+  IDEA: testing out this method of handling job kickoff. I think I like it, so
+  I may use it in other places. Just testing it for now
+
+  Returns {:ok, %Task{}} | {:error, :duplicate_job} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff_with_task(source) do
+    %{id: source.id}
+    |> SourceMetadataStorageWorker.new()
+    |> Tasks.create_job_with_task(source)
+  end
+
+  @impl Oban.Worker
+  @doc """
+  Fetches and stores metadata for a source in the secret metadata location.
+
+  Returns :ok
+  """
+  def perform(%Oban.Job{args: %{"id" => source_id}}) do
+    source = Repo.preload(Sources.get_source!(source_id), :metadata)
+    {:ok, metadata} = MediaCollection.get_source_metadata(source.original_url)
+
+    Sources.update_source(source, %{
+      metadata: %{
+        metadata_filepath: MetadataFileHelpers.compress_and_store_metadata_for(source, metadata)
+      }
+    })
+
+    :ok
+  end
+end

--- a/lib/pinchflat/tasks/tasks.ex
+++ b/lib/pinchflat/tasks/tasks.ex
@@ -20,6 +20,8 @@ defmodule Pinchflat.Tasks do
   Returns the list of tasks for a given record type and ID. Optionally allows you to specify
   which worker or job states to include.
 
+  IDEA: this should be updated to take a struct instead of a record type and ID
+
   Returns [%Task{}, ...]
   """
   def list_tasks_for(attached_record_type, attached_record_id, worker_name \\ nil, job_states \\ Oban.Job.states()) do

--- a/priv/repo/migrations/20240314174731_create_source_metadata.exs
+++ b/priv/repo/migrations/20240314174731_create_source_metadata.exs
@@ -1,0 +1,14 @@
+defmodule Pinchflat.Repo.Migrations.CreateSourceMetadata do
+  use Ecto.Migration
+
+  def change do
+    create table(:source_metadata) do
+      add :metadata_filepath, :string, null: false
+      add :source_id, references(:sources, on_delete: :delete_all), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:source_metadata, [:source_id])
+  end
+end

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -1,0 +1,55 @@
+defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
+  use Pinchflat.DataCase
+  import Mox
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.Metadata.SourceMetadataStorageWorker
+
+  setup :verify_on_exit!
+
+  describe "kickoff_with_task/1" do
+    test "enqueues a new worker for the source" do
+      source = source_fixture()
+
+      assert {:ok, _} = SourceMetadataStorageWorker.kickoff_with_task(source)
+
+      assert_enqueued(worker: SourceMetadataStorageWorker, args: %{"id" => source.id})
+    end
+
+    test "creates a new task for the source" do
+      source = source_fixture()
+
+      assert {:ok, task} = SourceMetadataStorageWorker.kickoff_with_task(source)
+
+      assert task.source_id == source.id
+    end
+  end
+
+  describe "perform/1" do
+    test "sets metadata location for source" do
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, "{}"} end)
+      source = Repo.preload(source_fixture(), :metadata)
+
+      refute source.metadata
+      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      source = Repo.preload(Repo.reload(source), :metadata)
+
+      assert source.metadata.metadata_filepath
+
+      File.rm!(source.metadata.metadata_filepath)
+    end
+
+    test "fetches and stores returned metadata for source" do
+      source = source_fixture()
+      file_contents = Phoenix.json_library().encode!(%{"title" => "test"})
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, file_contents} end)
+
+      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      source = Repo.preload(Repo.reload(source), :metadata)
+      {:ok, metadata} = MetadataFileHelpers.read_compressed_metadata(source.metadata.metadata_filepath)
+
+      assert metadata == %{"title" => "test"}
+    end
+  end
+end

--- a/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
+++ b/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
@@ -101,7 +101,10 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
       expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
 
       source = source_fixture(index_frequency_minutes: 10)
-      task_count_fetcher = fn -> Enum.count(Tasks.list_tasks()) end
+
+      task_count_fetcher = fn ->
+        Enum.count(Tasks.list_tasks_for(:source_id, source.id, "MediaCollectionIndexingWorker"))
+      end
 
       assert_changed([from: 0, to: 1], task_count_fetcher, fn ->
         perform_job(MediaCollectionIndexingWorker, %{id: source.id})

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -34,6 +34,20 @@ defmodule Pinchflat.SourcesFixtures do
     source
   end
 
+  @doc """
+  Generate a source with metadata.
+  """
+  def source_with_metadata(attrs \\ %{}) do
+    merged_attrs =
+      Map.merge(attrs, %{
+        metadata: %{
+          metadata_filepath: Application.get_env(:pinchflat, :metadata_directory) <> "/metadata.json.gz"
+        }
+      })
+
+    source_fixture(merged_attrs)
+  end
+
   def source_attributes_return_fixture do
     source_attributes = [
       %{


### PR DESCRIPTION
## What's new?

- Adds `source_metadata` model for tracking source metadata location
- Adds source metadata worker to fetch and store the aforementioned metadata. Kicks off when a source is created or updated

## What's changed?

- Renamed `media_local_metadata` queue to `local_metadata`

## What's fixed?

N/A

## Any other comments?

Works toward #73 as well as #77
