### PR TITLE
Misc refactors 2024-03-15

### DIFF
--- a/lib/pinchflat/downloading/media_download_worker.ex
+++ b/lib/pinchflat/downloading/media_download_worker.ex
@@ -6,6 +6,8 @@ defmodule Pinchflat.Downloading.MediaDownloadWorker do
     unique: [period: :infinity, states: [:available, :scheduled, :retryable, :executing]],
     tags: ["media_item", "media_fetching"]
 
+  require Logger
+
   alias __MODULE__
   alias Pinchflat.Tasks
   alias Pinchflat.Repo
@@ -42,6 +44,9 @@ defmodule Pinchflat.Downloading.MediaDownloadWorker do
     else
       :ok
     end
+  rescue
+    Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: media item #{media_item_id} not found")
+    Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: media item #{media_item_id} stale")
   end
 
   defp download_media_and_schedule_jobs(media_item) do

--- a/lib/pinchflat/fast_indexing/fast_indexing_worker.ex
+++ b/lib/pinchflat/fast_indexing/fast_indexing_worker.ex
@@ -6,6 +6,8 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorker do
     unique: [period: :infinity, states: [:available, :scheduled, :retryable]],
     tags: ["media_source", "fast_indexing"]
 
+  require Logger
+
   alias __MODULE__
   alias Pinchflat.Tasks
   alias Pinchflat.Sources
@@ -41,6 +43,9 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorker do
     else
       :ok
     end
+  rescue
+    Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
+    Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
   end
 
   defp reschedule_indexing(source) do

--- a/lib/pinchflat/fast_indexing/media_indexing_worker.ex
+++ b/lib/pinchflat/fast_indexing/media_indexing_worker.ex
@@ -62,5 +62,8 @@ defmodule Pinchflat.FastIndexing.MediaIndexingWorker do
     end
 
     :ok
+  rescue
+    Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
+    Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
   end
 end

--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -196,13 +196,14 @@ defmodule Pinchflat.Media do
   def delete_media_item(%MediaItem{} = media_item, opts \\ []) do
     delete_files = Keyword.get(opts, :delete_files, false)
 
+    Tasks.delete_tasks_for(media_item)
+
     if delete_files do
       {:ok, _} = delete_media_files(media_item)
     end
 
     # Should delete these no matter what
     delete_internal_metadata_files(media_item)
-    Tasks.delete_tasks_for(media_item)
     Repo.delete(media_item)
   end
 

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -9,6 +9,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     # in an infinite loop.
     unique: [period: 600]
 
+  require Logger
+
   alias __MODULE__
   alias Pinchflat.Repo
   alias Pinchflat.Tasks
@@ -47,5 +49,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     })
 
     :ok
+  rescue
+    Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
+    Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
   end
 end

--- a/lib/pinchflat/slow_indexing/media_collection_indexing_worker.ex
+++ b/lib/pinchflat/slow_indexing/media_collection_indexing_worker.ex
@@ -6,6 +6,8 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorker do
     unique: [period: :infinity, states: [:available, :scheduled, :retryable]],
     tags: ["media_source", "media_collection_indexing"]
 
+  require Logger
+
   alias __MODULE__
   alias Pinchflat.Tasks
   alias Pinchflat.Sources
@@ -90,6 +92,9 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorker do
         # perform a no-op
         :ok
     end
+  rescue
+    Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
+    Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
   end
 
   defp reschedule_indexing(source) do

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -103,6 +103,8 @@ defmodule Pinchflat.Sources do
   def delete_source(%Source{} = source, opts \\ []) do
     delete_files = Keyword.get(opts, :delete_files, false)
 
+    Tasks.delete_tasks_for(source)
+
     source
     |> Media.list_media_items_for()
     |> Enum.each(fn media_item ->
@@ -110,7 +112,6 @@ defmodule Pinchflat.Sources do
     end)
 
     delete_source_metadata_files(source)
-    Tasks.delete_tasks_for(source)
     Repo.delete(source)
   end
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -70,7 +70,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
   end
 
   defp media_center_output_template do
-    "/shows/{{ source_custom_name }}/{{ season_from_date }}/{{ season_episode_from_date }} - {{ title }}.{{ ext }}"
+    "/shows/{{ source_custom_name }}/Season {{ season_from_date }}/{{ season_episode_from_date }} - {{ title }}.{{ ext }}"
   end
 
   defp audio_output_template do

--- a/test/pinchflat/downloading/media_download_worker_test.exs
+++ b/test/pinchflat/downloading/media_download_worker_test.exs
@@ -95,5 +95,9 @@ defmodule Pinchflat.Downloading.MediaDownloadWorkerTest do
 
       assert media_item.media_size_bytes > 0
     end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(MediaDownloadWorker, %{id: 0})
+    end
   end
 end

--- a/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
@@ -31,13 +31,13 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       expect(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
       source = source_fixture(fast_index: true)
 
-      perform_job(FastIndexingWorker, %{"id" => source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
     end
 
     test "reschedules itself if fast indexing is enabled" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
       source = source_fixture(fast_index: true)
-      perform_job(FastIndexingWorker, %{"id" => source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
 
       assert_enqueued(
         worker: FastIndexingWorker,
@@ -50,8 +50,8 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       stub(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
       source = source_fixture(fast_index: true)
 
-      perform_job(FastIndexingWorker, %{"id" => source.id})
-      perform_job(FastIndexingWorker, %{"id" => source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
 
       assert [_] = all_enqueued(worker: FastIndexingWorker)
     end
@@ -60,14 +60,18 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       expect(HTTPClientMock, :get, 0, fn _url -> {:ok, ""} end)
       source = source_fixture(fast_index: false)
 
-      perform_job(FastIndexingWorker, %{"id" => source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
     end
 
     test "does not reschedule itself if fast indexing is disabled" do
       source = source_fixture(fast_index: false)
-      perform_job(FastIndexingWorker, %{"id" => source.id})
+      perform_job(FastIndexingWorker, %{id: source.id})
 
       refute_enqueued(worker: FastIndexingWorker, args: %{"id" => source.id})
+    end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(FastIndexingWorker, %{id: 0})
     end
   end
 end

--- a/test/pinchflat/fast_indexing/media_indexing_worker_test.exs
+++ b/test/pinchflat/fast_indexing/media_indexing_worker_test.exs
@@ -53,5 +53,9 @@ defmodule Pinchflat.FastIndexing.MediaIndexingWorkerTest do
 
       assert [_] = all_enqueued(worker: MediaDownloadWorker)
     end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(MediaDownloadWorker, %{id: 0, media_url: @media_url})
+    end
   end
 end

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -74,5 +74,9 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       assert [_, _] = all_enqueued(worker: SourceMetadataStorageWorker)
     end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: 0})
+    end
   end
 end

--- a/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
+++ b/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
@@ -161,5 +161,9 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
         perform_job(MediaCollectionIndexingWorker, %{id: source.id})
       end)
     end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(MediaCollectionIndexingWorker, %{id: 0})
+    end
   end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Jobs are discarded if they raise an `Ecto.NoResultsError` or `Ecto.StaleEntryError`

## What's fixed?

- Possibly addresses a bug of unknown cause that happens when you delete a source immediately after starting indexing

## Any other comments?

N/A
