### PR TITLE
Source NFO downloads

### DIFF
--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -56,7 +56,9 @@ defmodule Pinchflat.Downloading.MediaDownloader do
 
   defp determine_nfo_filepath(media_item, parsed_json) do
     if media_item.source.media_profile.download_nfo do
-      NfoBuilder.build_and_store_for_media_item(parsed_json)
+      filepath = Path.rootname(parsed_json["filepath"]) <> ".nfo"
+
+      NfoBuilder.build_and_store_for_media_item(filepath, parsed_json)
     else
       nil
     end

--- a/lib/pinchflat/metadata/nfo_builder.ex
+++ b/lib/pinchflat/metadata/nfo_builder.ex
@@ -9,13 +9,11 @@ defmodule Pinchflat.Metadata.NfoBuilder do
 
   @doc """
   Builds an NFO file for a media item (read: single "episode") and
-  stores it in the same directory as the media file. Has the same name
-  as the media file, but with a .nfo extension.
+  stores it at the specified location.
 
   Returns the filepath of the NFO file.
   """
-  def build_and_store_for_media_item(metadata) do
-    filepath = Path.rootname(metadata["filepath"]) <> ".nfo"
+  def build_and_store_for_media_item(filepath, metadata) do
     nfo = build_for_media_item(metadata)
 
     FilesystemHelpers.write_p!(filepath, nfo)

--- a/lib/pinchflat/metadata/nfo_builder.ex
+++ b/lib/pinchflat/metadata/nfo_builder.ex
@@ -34,7 +34,7 @@ defmodule Pinchflat.Metadata.NfoBuilder do
       <showtitle>#{metadata["uploader"]}</showtitle>
       <uniqueid type="youtube" default="true">#{metadata["id"]}</uniqueid>
       <plot>#{metadata["description"]}</plot>
-      <premiered>#{upload_date}</premiered>
+      <aired>#{upload_date}</aired>
       <season>#{upload_date.year}</season>
       <episode>#{Calendar.strftime(upload_date, "%m%d")}</episode>
       <genre>YouTube</genre>

--- a/lib/pinchflat/metadata/nfo_builder.ex
+++ b/lib/pinchflat/metadata/nfo_builder.ex
@@ -21,6 +21,20 @@ defmodule Pinchflat.Metadata.NfoBuilder do
     filepath
   end
 
+  @doc """
+  Builds an NFO file for a souce and stores it at the specified location.
+  Technically works for playlists, but it's really made for channels.
+
+  Returns the filepath of the NFO file.
+  """
+  def build_and_store_for_source(filepath, metadata) do
+    nfo = build_for_source(metadata)
+
+    FilesystemHelpers.write_p!(filepath, nfo)
+
+    filepath
+  end
+
   defp build_for_media_item(metadata) do
     upload_date = MetadataFileHelpers.parse_upload_date(metadata["upload_date"])
     # Cribbed from a combination of the Kodi wiki, ytdl-nfo, and ytdl-sub.
@@ -37,6 +51,18 @@ defmodule Pinchflat.Metadata.NfoBuilder do
       <episode>#{Calendar.strftime(upload_date, "%m%d")}</episode>
       <genre>YouTube</genre>
     </episodedetails>
+    """
+  end
+
+  defp build_for_source(metadata) do
+    """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+    <tvshow>
+      <title>#{metadata["title"]}</title>
+      <plot>#{metadata["description"]}</plot>
+      <uniqueid type="youtube" default="true">#{metadata["id"]}</uniqueid>
+      <genre>YouTube</genre>
+    </tvshow>
     """
   end
 end

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -4,7 +4,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   use Oban.Worker,
     queue: :remote_metadata,
     tags: ["media_source", "source_metadata", "remote_metadata"],
-    max_attempts: 1,
+    max_attempts: 3,
     # This is the only thing stopping this job from calling itself
     # in an infinite loop. Time is in seconds
     unique: [period: 120]
@@ -15,6 +15,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   alias Pinchflat.Repo
   alias Pinchflat.Tasks
   alias Pinchflat.Sources
+  alias Pinchflat.Metadata.NfoBuilder
   alias Pinchflat.YtDlp.MediaCollection
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Downloading.DownloadOptionBuilder
@@ -41,6 +42,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"id" => source_id}}) do
     source = Repo.preload(Sources.get_source!(source_id), [:metadata, :media_profile])
+    source_metadata = fetch_source_metadata(source)
     series_directory = determine_series_directory(source)
 
     # Since updating a source kicks this job off again, we enforce job uniqueness (above)
@@ -48,8 +50,9 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     # in an infinite loop.
     Sources.update_source(source, %{
       series_directory: series_directory,
+      nfo_filepath: store_source_nfo(source, series_directory, source_metadata),
       metadata: %{
-        metadata_filepath: store_source_metadata(source)
+        metadata_filepath: store_source_metadata(source, source_metadata)
       }
     })
 
@@ -59,9 +62,13 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
   end
 
-  defp store_source_metadata(source) do
+  defp fetch_source_metadata(source) do
     {:ok, metadata} = MediaCollection.get_source_metadata(source.original_url)
 
+    metadata
+  end
+
+  defp store_source_metadata(source, metadata) do
     MetadataFileHelpers.compress_and_store_metadata_for(source, metadata)
   end
 
@@ -72,6 +79,14 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     case MetadataFileHelpers.series_directory_from_media_filepath(filepath) do
       {:ok, series_directory} -> series_directory
       {:error, _} -> nil
+    end
+  end
+
+  defp store_source_nfo(source, series_directory, metadata) do
+    if source.download_nfo && series_directory do
+      nfo_filepath = Path.join(series_directory, "tvshow.nfo")
+
+      NfoBuilder.build_and_store_for_source(nfo_filepath, metadata)
     end
   end
 end

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -86,7 +86,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   end
 
   defp store_source_nfo(source, series_directory, metadata) do
-    if source.download_nfo && series_directory do
+    if source.media_profile.download_nfo && series_directory do
       nfo_filepath = Path.join(series_directory, "tvshow.nfo")
 
       NfoBuilder.build_and_store_for_source(nfo_filepath, metadata)

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -6,8 +6,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     tags: ["media_source", "source_metadata", "remote_metadata"],
     max_attempts: 1,
     # This is the only thing stopping this job from calling itself
-    # in an infinite loop.
-    unique: [period: 600]
+    # in an infinite loop. Time is in seconds
+    unique: [period: 120]
 
   require Logger
 
@@ -17,6 +17,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   alias Pinchflat.Sources
   alias Pinchflat.YtDlp.MediaCollection
   alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.Downloading.DownloadOptionBuilder
 
   @doc """
   Starts the source metadata storage worker and creates a task for the source.
@@ -30,21 +31,25 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   end
 
   @doc """
-  Fetches and stores metadata for a source in the secret metadata location.
+  Fetches and stores various forms of metadata for a source:
+    - JSON metadata for internal use
+    - The series directory for the source
+    - The NFO file for the source (if specified)
 
   Returns :ok
   """
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"id" => source_id}}) do
-    source = Repo.preload(Sources.get_source!(source_id), :metadata)
-    {:ok, metadata} = MediaCollection.get_source_metadata(source.original_url)
+    source = Repo.preload(Sources.get_source!(source_id), [:metadata, :media_profile])
+    series_directory = determine_series_directory(source)
 
     # Since updating a source kicks this job off again, we enforce job uniqueness (above)
     # to once, per source, per x minutes. This is to prevent a job from calling itself
     # in an infinite loop.
     Sources.update_source(source, %{
+      series_directory: series_directory,
       metadata: %{
-        metadata_filepath: MetadataFileHelpers.compress_and_store_metadata_for(source, metadata)
+        metadata_filepath: store_source_metadata(source)
       }
     })
 
@@ -52,5 +57,21 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   rescue
     Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
     Ecto.StaleEntryError -> Logger.info("#{__MODULE__} discarded: source #{source_id} stale")
+  end
+
+  defp store_source_metadata(source) do
+    {:ok, metadata} = MediaCollection.get_source_metadata(source.original_url)
+
+    MetadataFileHelpers.compress_and_store_metadata_for(source, metadata)
+  end
+
+  defp determine_series_directory(source) do
+    output_path = DownloadOptionBuilder.build_output_path_for(source)
+    {:ok, %{filepath: filepath}} = MediaCollection.get_source_details(source.original_url, output: output_path)
+
+    case MetadataFileHelpers.series_directory_from_media_filepath(filepath) do
+      {:ok, series_directory} -> series_directory
+      {:error, _} -> nil
+    end
   end
 end

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -106,4 +106,9 @@ defmodule Pinchflat.Sources.Source do
     # minutes
     15
   end
+
+  @doc false
+  def filepath_attributes do
+    ~w(nfo_filepath)a
+  end
 end

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -17,6 +17,9 @@ defmodule Pinchflat.Sources.Source do
     collection_id
     collection_type
     custom_name
+    download_nfo
+    nfo_filepath
+    series_directory
     index_frequency_minutes
     fast_index
     download_media
@@ -37,6 +40,7 @@ defmodule Pinchflat.Sources.Source do
     download_media
     original_url
     media_profile_id
+    download_nfo
   )a
 
   @pre_insert_required_fields @initially_required_fields ++
@@ -52,6 +56,9 @@ defmodule Pinchflat.Sources.Source do
     field :collection_name, :string
     field :collection_id, :string
     field :collection_type, Ecto.Enum, values: [:channel, :playlist]
+    field :download_nfo, :boolean, default: false
+    field :nfo_filepath, :string
+    field :series_directory, :string
     field :index_frequency_minutes, :integer, default: 60 * 24
     field :fast_index, :boolean, default: false
     field :download_media, :boolean, default: true

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -17,7 +17,6 @@ defmodule Pinchflat.Sources.Source do
     collection_id
     collection_type
     custom_name
-    download_nfo
     nfo_filepath
     series_directory
     index_frequency_minutes
@@ -40,7 +39,6 @@ defmodule Pinchflat.Sources.Source do
     download_media
     original_url
     media_profile_id
-    download_nfo
   )a
 
   @pre_insert_required_fields @initially_required_fields ++
@@ -56,7 +54,6 @@ defmodule Pinchflat.Sources.Source do
     field :collection_name, :string
     field :collection_id, :string
     field :collection_type, Ecto.Enum, values: [:channel, :playlist]
-    field :download_nfo, :boolean, default: false
     field :nfo_filepath, :string
     field :series_directory, :string
     field :index_frequency_minutes, :integer, default: 60 * 24

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -147,9 +147,7 @@ defmodule Pinchflat.Sources do
   end
 
   defp add_source_details_to_changeset(source, changeset) do
-    %Ecto.Changeset{changes: changes} = changeset
-
-    case MediaCollection.get_source_details(changes.original_url) do
+    case MediaCollection.get_source_details(changeset.changes.original_url) do
       {:ok, source_details} ->
         add_source_details_by_collection_type(source, changeset, source_details)
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -162,16 +162,6 @@
       />
     </section>
 
-    <section x-data="{ presets: { default: false, media_center: true, audio: false, archiving: true } }">
-      <.input
-        field={f[:download_nfo]}
-        type="toggle"
-        label="Download episode NFO data"
-        help="Downloads episode NFO data alongside media file for use with Jellyfin, Kodi, etc."
-        x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
-      />
-    </section>
-
     <h3 class="mt-10 text-2xl text-black dark:text-white">
       Release Format Options
     </h3>
@@ -210,6 +200,29 @@
         label="Preferred Resolution"
         help="Will grab the closest available resolution if your preferred is not available. 'Audio Only' grabs the highest quality m4a"
         x-init="$watch('selectedPreset', p => p && ($el.value = presets[p]))"
+      />
+    </section>
+
+    <h3 class="mt-8 text-2xl text-black dark:text-white">
+      Media Center Options
+    </h3>
+    <p class="text-sm mt-2 max-w-prose">
+      Everything in this section is experimental - please open a GitHub issue if you see something odd.
+      These options only work if this Media Profile's output template is set to split media into seasons.
+      Try the "Media Center" preset if you're not sure.
+    </p>
+
+    <section
+      phx-click={show_modal("upgrade-modal")}
+      x-data="{ presets: { default: false, media_center: true, audio: false, archiving: false } }"
+    >
+      <.input
+        field={f[:download_nfo]}
+        type="toggle"
+        label="Download NFO data"
+        label_suffix="(pro)"
+        help="Downloads NFO data alongside media file for use with Jellyfin, Kodi, etc."
+        x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
       />
     </section>
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -166,8 +166,8 @@
       <.input
         field={f[:download_nfo]}
         type="toggle"
-        label="Download NFO data"
-        help="Downloads NFO data alongside media file for use with Jellyfin, Kodi, etc."
+        label="Download episode NFO data"
+        help="Downloads episode NFO data alongside media file for use with Jellyfin, Kodi, etc."
         x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
       />
     </section>
@@ -181,7 +181,7 @@
         field={f[:shorts_behaviour]}
         options={friendly_format_type_options()}
         type="select"
-        label="Include Shorts?"
+        label="Include Shorts"
         help="Experimental. Please report any issues on GitHub"
         x-init="$watch('selectedPreset', p => p && ($el.value = presets[p]))"
       />
@@ -192,7 +192,7 @@
         field={f[:livestream_behaviour]}
         options={friendly_format_type_options()}
         type="select"
-        label="Include Livestreams?"
+        label="Include Livestreams"
         help="Excludes media that comes from a past livestream"
         x-init="$watch('selectedPreset', p => p && ($el.value = presets[p]))"
       />

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -69,22 +69,6 @@
     help="Only download media uploaded after this date. Leave blank to download all media. Must be in YYYY-MM-DD format"
   />
 
-  <h3 class="mt-8 text-2xl text-black dark:text-white">
-    Metadata Options
-  </h3>
-  <p class="text-sm mt-2 max-w-prose">
-    Everything in this section is experimental - please open a GitHub issue if you see something odd.
-    These options only work if your Media Profile's output template is set to split media into seasons.
-    Try the "Media Center" preset for Media Profiles if you're not sure.
-  </p>
-
-  <.input
-    field={f[:download_nfo]}
-    type="toggle"
-    label="Download series NFO data"
-    help="Downloads series NFO data for use with Jellyfin, Kodi, etc. Uneffected by 'Download Media'"
-  />
-
   <.button class="my-10 sm:mb-7.5 w-full sm:w-auto">Save Source</.button>
 
   <div class="rounded-sm dark:bg-meta-4 p-4 md:p-6 mb-5">

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -41,7 +41,7 @@
     <.input
       field={f[:fast_index]}
       type="toggle"
-      label="Use Fast Indexing?"
+      label="Use Fast Indexing"
       label_suffix="(pro)"
       help="Experimental. Ignores 'Index Frequency'. Recommended for large channels that upload frequently. See below for more info"
     />
@@ -54,7 +54,7 @@
   <.input
     field={f[:download_media]}
     type="toggle"
-    label="Download Media?"
+    label="Download Media"
     help="Unchecking still indexes media but it won't be downloaded until you enable this option"
   />
 
@@ -67,6 +67,22 @@
     pattern="((?:19|20)[0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
     title="YYYY-MM-DD"
     help="Only download media uploaded after this date. Leave blank to download all media. Must be in YYYY-MM-DD format"
+  />
+
+  <h3 class="mt-8 text-2xl text-black dark:text-white">
+    Metadata Options
+  </h3>
+  <p class="text-sm mt-2 max-w-prose">
+    Everything in this section is experimental - please open a GitHub issue if you see something odd.
+    These options only work if your Media Profile's output template is set to split media into seasons.
+    Try the "Media Center" preset for Media Profiles if you're not sure.
+  </p>
+
+  <.input
+    field={f[:download_nfo]}
+    type="toggle"
+    label="Download series NFO data"
+    help="Downloads series NFO data for use with Jellyfin, Kodi, etc. Uneffected by 'Download Media'"
   />
 
   <.button class="my-10 sm:mb-7.5 w-full sm:w-auto">Save Source</.button>

--- a/priv/repo/migrations/20240318161405_add_nfo_path_to_sources.exs
+++ b/priv/repo/migrations/20240318161405_add_nfo_path_to_sources.exs
@@ -1,0 +1,11 @@
+defmodule Pinchflat.Repo.Migrations.AddNfoPathToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :download_nfo, :boolean, default: false, null: false
+      add :nfo_filepath, :string
+      add :series_directory, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20240318161405_add_nfo_path_to_sources.exs
+++ b/priv/repo/migrations/20240318161405_add_nfo_path_to_sources.exs
@@ -3,7 +3,6 @@ defmodule Pinchflat.Repo.Migrations.AddNfoPathToSources do
 
   def change do
     alter table(:sources) do
-      add :download_nfo, :boolean, default: false, null: false
       add :nfo_filepath, :string
       add :series_directory, :string
     end

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -222,6 +222,14 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
     end
   end
 
+  describe "build_output_path_for/1" do
+    test "builds an output path for a source", %{media_item: media_item} do
+      path = DownloadOptionBuilder.build_output_path_for(media_item.source)
+
+      assert path == "/tmp/test/media/%(title)S.%(ext)s"
+    end
+  end
+
   defp update_media_profile_attribute(media_item_with_preloads, attrs) do
     media_item_with_preloads.source.media_profile
     |> Profiles.change_media_profile(attrs)

--- a/test/pinchflat/metadata/metadata_file_helpers_test.exs
+++ b/test/pinchflat/metadata/metadata_file_helpers_test.exs
@@ -92,4 +92,52 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
       assert Helpers.parse_upload_date(upload_date) == ~D[2021-01-01]
     end
   end
+
+  describe "series_directory_from_media_filepath/1" do
+    test "returns base series directory if filepaths are setup as expected" do
+      good_filepaths = [
+        "/media/season1/episode.mp4",
+        "/media/season 1/episode.mp4",
+        "/media/season.1/episode.mp4",
+        "/media/season_1/episode.mp4",
+        "/media/season-1/episode.mp4",
+        "/media/SEASON 1/episode.mp4",
+        "/media/SEASON.1/episode.mp4",
+        "/media/s1/episode.mp4",
+        "/media/s.1/episode.mp4",
+        "/media/s_1/episode.mp4",
+        "/media/s-1/episode.mp4",
+        "/media/s 1/episode.mp4",
+        "/media/S1/episode.mp4",
+        "/media/S.1/episode.mp4"
+      ]
+
+      for filepath <- good_filepaths do
+        assert {:ok, "/media"} = Helpers.series_directory_from_media_filepath(filepath)
+      end
+    end
+
+    test "returns an error if the season filepath can't be determined" do
+      bad_filepaths = [
+        "/media/1/episode.mp4",
+        "/media/(s1)/episode.mp4",
+        "/media/episode.mp4",
+        "/media/s1e1/episode.mp4",
+        "/media/s1 e1/episode.mp4",
+        "/media/s1 (something else)/episode.mp4",
+        "/media/season1e1/episode.mp4",
+        "/media/season1 e1/episode.mp4",
+        "/media/seasoning1/episode.mp4",
+        "/media/season/episode.mp4",
+        "/media/series1/episode.mp4",
+        "/media/s/episode.mp4",
+        "/media/foo",
+        "/media/bar/"
+      ]
+
+      for filepath <- bad_filepaths do
+        assert {:error, :indeterminable} = Helpers.series_directory_from_media_filepath(filepath)
+      end
+    end
+  end
 end

--- a/test/pinchflat/metadata/nfo_builder_test.exs
+++ b/test/pinchflat/metadata/nfo_builder_test.exs
@@ -31,4 +31,20 @@ defmodule Pinchflat.Metadata.NfoBuilderTest do
       assert String.contains?(nfo, "<title>#{metadata["title"]}</title>")
     end
   end
+
+  describe "build_and_store_for_source/2" do
+    test "returns the filepath", %{metadata: metadata, filepath: filepath} do
+      result = NfoBuilder.build_and_store_for_source(filepath, metadata)
+
+      assert File.exists?(result)
+    end
+
+    test "builds an NFO file", %{metadata: metadata, filepath: filepath} do
+      result = NfoBuilder.build_and_store_for_source(filepath, metadata)
+      nfo = File.read!(result)
+
+      assert String.contains?(nfo, ~S(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>))
+      assert String.contains?(nfo, "<title>#{metadata["title"]}</title>")
+    end
+  end
 end

--- a/test/pinchflat/metadata/nfo_builder_test.exs
+++ b/test/pinchflat/metadata/nfo_builder_test.exs
@@ -2,37 +2,33 @@ defmodule Pinchflat.Metadata.NfoBuilderTest do
   use Pinchflat.DataCase
 
   alias Pinchflat.Metadata.NfoBuilder
+  alias Pinchflat.Filesystem.FilesystemHelpers
 
   setup do
-    {:ok, %{metadata: render_parsed_metadata(:media_metadata)}}
+    filepath = FilesystemHelpers.generate_metadata_tmpfile(:json)
+
+    on_exit(fn -> File.rm!(filepath) end)
+
+    {:ok,
+     %{
+       metadata: render_parsed_metadata(:media_metadata),
+       filepath: filepath
+     }}
   end
 
-  describe "build_and_store_for_media_item/1" do
-    test "returns the filepath", %{metadata: metadata} do
-      result = NfoBuilder.build_and_store_for_media_item(metadata)
+  describe "build_and_store_for_media_item/2" do
+    test "returns the filepath", %{metadata: metadata, filepath: filepath} do
+      result = NfoBuilder.build_and_store_for_media_item(filepath, metadata)
 
       assert File.exists?(result)
-
-      File.rm!(result)
     end
 
-    test "builds filepath based on media location", %{metadata: metadata} do
-      result = NfoBuilder.build_and_store_for_media_item(metadata)
-
-      assert String.contains?(result, Path.rootname(metadata["filepath"]))
-      assert String.ends_with?(result, ".nfo")
-
-      File.rm!(result)
-    end
-
-    test "builds an NFO file", %{metadata: metadata} do
-      result = NfoBuilder.build_and_store_for_media_item(metadata)
+    test "builds an NFO file", %{metadata: metadata, filepath: filepath} do
+      result = NfoBuilder.build_and_store_for_media_item(filepath, metadata)
       nfo = File.read!(result)
 
       assert String.contains?(nfo, ~S(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>))
       assert String.contains?(nfo, "<title>#{metadata["title"]}</title>")
-
-      File.rm!(result)
     end
   end
 end

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -2,6 +2,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
   use Pinchflat.DataCase
   import Mox
   import Pinchflat.SourcesFixtures
+  import Pinchflat.ProfilesFixtures
 
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Metadata.SourceMetadataStorageWorker
@@ -133,7 +134,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
           {:ok, "{}"}
       end)
 
-      source = source_fixture(%{download_nfo: true, nfo_filepath: nil})
+      profile = media_profile_fixture(%{download_nfo: true})
+      source = source_fixture(%{nfo_filepath: nil, media_profile_id: profile.id})
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
       source = Repo.reload(source)
 
@@ -155,7 +157,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
           {:ok, "{}"}
       end)
 
-      source = source_fixture(%{download_nfo: false, nfo_filepath: nil})
+      profile = media_profile_fixture(%{download_nfo: false})
+      source = source_fixture(%{nfo_filepath: nil, media_profile_id: profile.id})
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
       source = Repo.reload(source)
 
@@ -173,7 +176,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
           {:ok, "{}"}
       end)
 
-      source = source_fixture(%{download_nfo: true, nfo_filepath: nil})
+      profile = media_profile_fixture(%{download_nfo: true})
+      source = source_fixture(%{nfo_filepath: nil, media_profile_id: profile.id})
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
       source = Repo.reload(source)
 

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -39,26 +39,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
       source = source_fixture()
 
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source.id})
 
-      assert [_] = all_enqueued(worker: SourceMetadataStorageWorker)
-    end
-
-    test "doesn't prevent over source jobs from running" do
-      stub(YtDlpRunnerMock, :run, fn
-        _url, _opts, ot when ot == @source_details_ot -> {:ok, source_details_return_fixture()}
-        _url, _opts, ot when ot == @metadata_ot -> {:ok, "{}"}
-      end)
-
-      source_1 = source_fixture()
-      source_2 = source_fixture()
-
-      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
-
-      assert [_, _] = all_enqueued(worker: SourceMetadataStorageWorker)
+      assert [] = all_enqueued(worker: SourceMetadataStorageWorker)
     end
 
     test "does not blow up if the record doesn't exist" do

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -6,6 +6,9 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Metadata.SourceMetadataStorageWorker
 
+  @source_details_ot "%(.{channel,channel_id,playlist_id,playlist_title,filename})j"
+  @metadata_ot "playlist:%()j"
+
   setup :verify_on_exit!
 
   describe "kickoff_with_task/1" do
@@ -27,8 +30,49 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
   end
 
   describe "perform/1" do
+    test "won't call itself in an infinite loop" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot -> {:ok, source_details_return_fixture()}
+        _url, _opts, ot when ot == @metadata_ot -> {:ok, "{}"}
+      end)
+
+      source = source_fixture()
+
+      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      assert [_] = all_enqueued(worker: SourceMetadataStorageWorker)
+    end
+
+    test "doesn't prevent over source jobs from running" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot -> {:ok, source_details_return_fixture()}
+        _url, _opts, ot when ot == @metadata_ot -> {:ok, "{}"}
+      end)
+
+      source_1 = source_fixture()
+      source_2 = source_fixture()
+
+      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
+      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
+      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
+      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
+
+      assert [_, _] = all_enqueued(worker: SourceMetadataStorageWorker)
+    end
+
+    test "does not blow up if the record doesn't exist" do
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: 0})
+    end
+  end
+
+  describe "perform/1 when testing metadata storage" do
     test "sets metadata location for source" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, "{}"} end)
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot -> {:ok, source_details_return_fixture()}
+        _url, _opts, ot when ot == @metadata_ot -> {:ok, "{}"}
+      end)
+
       source = Repo.preload(source_fixture(), :metadata)
 
       refute source.metadata
@@ -43,7 +87,11 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
     test "fetches and stores returned metadata for source" do
       source = source_fixture()
       file_contents = Phoenix.json_library().encode!(%{"title" => "test"})
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, file_contents} end)
+
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot -> {:ok, source_details_return_fixture()}
+        _url, _opts, ot when ot == @metadata_ot -> {:ok, file_contents}
+      end)
 
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
       source = Repo.preload(Repo.reload(source), :metadata)
@@ -51,32 +99,43 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       assert metadata == %{"title" => "test"}
     end
+  end
 
-    test "won't call itself in an infinite loop" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, "{}"} end)
-      source = source_fixture()
+  describe "perform/1 when determining the series_directory" do
+    test "sets the series directory based on the returned media filepath" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot ->
+          filename = Path.join([Application.get_env(:pinchflat, :media_directory), "Season 1", "bar.mp4"])
 
+          {:ok, source_details_return_fixture(%{filename: filename})}
+
+        _url, _opts, ot when ot == @metadata_ot ->
+          {:ok, "{}"}
+      end)
+
+      source = source_fixture(%{series_directory: nil})
       perform_job(SourceMetadataStorageWorker, %{id: source.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      source = Repo.reload(source)
 
-      assert [_] = all_enqueued(worker: SourceMetadataStorageWorker)
+      assert source.series_directory
     end
 
-    test "doesn't prevent over source jobs from running" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot -> {:ok, "{}"} end)
-      source_1 = source_fixture()
-      source_2 = source_fixture()
+    test "does not set the series directory if it cannot be determined" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, _opts, ot when ot == @source_details_ot ->
+          filename = Path.join([Application.get_env(:pinchflat, :media_directory), "foo", "bar.mp4"])
 
-      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_1.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
-      perform_job(SourceMetadataStorageWorker, %{id: source_2.id})
+          {:ok, source_details_return_fixture(%{filename: filename})}
 
-      assert [_, _] = all_enqueued(worker: SourceMetadataStorageWorker)
-    end
+        _url, _opts, ot when ot == @metadata_ot ->
+          {:ok, "{}"}
+      end)
 
-    test "does not blow up if the record doesn't exist" do
-      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: 0})
+      source = source_fixture(%{series_directory: nil})
+      perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      source = Repo.reload(source)
+
+      refute source.series_directory
     end
   end
 end

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -8,6 +8,7 @@ defmodule Pinchflat.SourcesTest do
 
   alias Pinchflat.Sources
   alias Pinchflat.Sources.Source
+  alias Pinchflat.Filesystem.FilesystemHelpers
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Downloading.DownloadingHelpers
   alias Pinchflat.FastIndexing.FastIndexingWorker
@@ -474,8 +475,18 @@ defmodule Pinchflat.SourcesTest do
 
       {:ok, updated_source} = Sources.update_source(source, update_attrs)
 
-      assert {:ok, _} = Sources.delete_source(updated_source, delete_files: true)
+      assert {:ok, _} = Sources.delete_source(updated_source)
       refute File.exists?(updated_source.metadata.metadata_filepath)
+    end
+
+    test "does not delete the source's non-metadata files" do
+      filepath = FilesystemHelpers.generate_metadata_tmpfile(:nfo)
+      source = source_fixture(%{nfo_filepath: filepath})
+
+      assert {:ok, _} = Sources.delete_source(source)
+      assert File.exists?(filepath)
+
+      File.rm!(filepath)
     end
   end
 
@@ -497,6 +508,15 @@ defmodule Pinchflat.SourcesTest do
       assert {:ok, %Source{}} = Sources.delete_source(source, delete_files: true)
 
       refute File.exists?(media_item.media_filepath)
+    end
+
+    test "deletes the source's non-metadata files" do
+      filepath = FilesystemHelpers.generate_metadata_tmpfile(:nfo)
+      source = source_fixture(%{nfo_filepath: filepath})
+
+      assert {:ok, _} = Sources.delete_source(source, delete_files: true)
+
+      refute File.exists?(filepath)
     end
   end
 

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -97,7 +97,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     test "it passes the expected args to the backend runner" do
       expect(YtDlpRunnerMock, :run, fn @channel_url, opts, ot ->
         assert opts == [:simulate, :skip_download, :ignore_no_formats_error, playlist_end: 1]
-        assert ot == "%(.{channel,channel_id,playlist_id,playlist_title})j"
+        assert ot == "%(.{channel,channel_id,playlist_id,playlist_title,filename})j"
 
         {:ok, "{}"}
       end)

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -85,4 +85,18 @@ defmodule Pinchflat.SourcesFixtures do
     source_attributes
     |> Enum.map_join("\n", &Phoenix.json_library().encode!(&1))
   end
+
+  def source_details_return_fixture(attrs \\ %{}) do
+    channel_id = Faker.String.base64(12)
+
+    %{
+      channel_id: channel_id,
+      channel: "Channel Name",
+      playlist_id: channel_id,
+      playlist_title: "Channel Name",
+      filename: Path.join([Application.get_env(:pinchflat, :media_directory), "foo", "bar.mp4"])
+    }
+    |> Map.merge(attrs)
+    |> Phoenix.json_library().encode!()
+  end
 end


### PR DESCRIPTION
## What's new?

- Adds new fields to Source model for handling NFOs (`download_nfo`, `series_directory`, and `nfo_filepath`)
- Adds methods for determining the source's root filepath if it contains episodic media
- Adds methods for generating and storing an NFO for a source. Works toward #73 

## What's changed?

- Updates source metadata worker to run `series_directory` determination as well as building + storing the NFO (if specified)

## What's fixed?

- Removes `premiered` tag in episode NFO and replaces it with the proper `aired` tag

## Any other comments?

N/A
