### PR TITLE
Misc indexing improvements

### DIFF
--- a/lib/pinchflat/slow_indexing/file_follower_server.ex
+++ b/lib/pinchflat/slow_indexing/file_follower_server.ex
@@ -9,7 +9,7 @@ defmodule Pinchflat.SlowIndexing.FileFollowerServer do
   require Logger
 
   @poll_interval_ms Application.compile_env(:pinchflat, :file_watcher_poll_interval)
-  @activity_timeout_ms 60_000
+  @activity_timeout_ms 600_000
 
   # Client API
   @doc """

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -98,7 +98,6 @@ defmodule Pinchflat.Sources.Source do
     |> dynamic_default(:custom_name, fn cs -> get_field(cs, :collection_name) end)
     |> validate_required(required_fields)
     |> cast_assoc(:metadata, with: &SourceMetadata.changeset/2, required: false)
-    |> unique_constraint([:collection_id, :media_profile_id])
   end
 
   @doc false

--- a/priv/repo/migrations/20240320181210_remove_unique_index_from_sources.exs
+++ b/priv/repo/migrations/20240320181210_remove_unique_index_from_sources.exs
@@ -1,0 +1,7 @@
+defmodule Pinchflat.Repo.Migrations.RemoveUniqueIndexFromSources do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:sources, [:collection_id, :media_profile_id])
+  end
+end

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -138,49 +138,6 @@ defmodule Pinchflat.SourcesTest do
       assert {:error, %Ecto.Changeset{}} = Sources.create_source(@invalid_source_attrs)
     end
 
-    test "creation enforces uniqueness of collection_id scoped to the media_profile" do
-      expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot ->
-        {:ok,
-         Phoenix.json_library().encode!(%{
-           channel: "some channel name",
-           channel_id: "some_channel_id_12345678",
-           playlist_id: "some_channel_id_12345678",
-           playlist_title: "some channel name - videos"
-         })}
-      end)
-
-      valid_once_attrs = %{
-        media_profile_id: media_profile_fixture().id,
-        original_url: "https://www.youtube.com/channel/abc123"
-      }
-
-      assert {:ok, %Source{}} = Sources.create_source(valid_once_attrs)
-      assert {:error, %Ecto.Changeset{}} = Sources.create_source(valid_once_attrs)
-    end
-
-    test "creation lets you duplicate collection_ids as long as the media profile is different" do
-      expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot ->
-        {:ok,
-         Phoenix.json_library().encode!(%{
-           channel: "some channel name",
-           channel_id: "some_channel_id_12345678",
-           playlist_id: "some_channel_id_12345678",
-           playlist_title: "some channel name - videos"
-         })}
-      end)
-
-      valid_attrs = %{
-        name: "some name",
-        original_url: "https://www.youtube.com/channel/abc123"
-      }
-
-      source_1_attrs = Map.merge(valid_attrs, %{media_profile_id: media_profile_fixture().id})
-      source_2_attrs = Map.merge(valid_attrs, %{media_profile_id: media_profile_fixture().id})
-
-      assert {:ok, %Source{}} = Sources.create_source(source_1_attrs)
-      assert {:ok, %Source{}} = Sources.create_source(source_2_attrs)
-    end
-
     test "creation will schedule the indexing task" do
       expect(YtDlpRunnerMock, :run, &channel_mock/3)
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Updates `FileFollowerServer`'s inactivity timeout from 1 minute to 10
  - This has been working well and adding more headroom in case of slow requests is a good idea
- Removes the unique index that prevented multiple of the same sources being added to a media profile
  - With the release of #98, there's now a valid use-case for using the same source multiple times with different regexes
- Updates various slow indexing methods to reload the source they're working with to pick up changes to settings like `download_media`. 
  - This allows that setting to be changed mid-index and it'll start respecting it from that point on

## What's fixed?

N/A

## Any other comments?

N/A
