### PR TITLE
Adds a method for retrying stuck jobs

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -21,31 +21,3 @@ alias Pinchflat.FastIndexing.YoutubeRss
 alias Pinchflat.Metadata.MetadataFileHelpers
 
 alias Pinchflat.SlowIndexing.FileFollowerServer
-
-defmodule IexHelpers do
-  def last_media_item do
-    Repo.one(from m in MediaItem, limit: 1)
-  end
-
-  def details(type) do
-    source =
-      case type do
-        :playlist -> playlist_url()
-        :channel -> channel_url()
-      end
-
-    YtDlpCollection.get_source_details(source)
-  end
-
-  def ids(type) do
-    source =
-      case type do
-        :playlist -> playlist_url()
-        :channel -> channel_url()
-      end
-
-    YtDlpCollection.get_media_attributes_for_collection(source)
-  end
-end
-
-import IexHelpers


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Adds pre-job startup task to set all jobs stuck in the `executing` state to `retryable` (resolves #111)

## Any other comments?

N/A

