### PR TITLE
Improve default recommendation for artist placeholder

### DIFF
--- a/lib/pinchflat/downloading/output_path_builder.ex
+++ b/lib/pinchflat/downloading/output_path_builder.ex
@@ -42,7 +42,8 @@ defmodule Pinchflat.Downloading.OutputPathBuilder do
       "upload_day" => "%(upload_date>%d)S",
       "upload_yyyy_mm_dd" => "%(upload_date>%Y-%m-%d)S",
       "season_from_date" => "%(upload_date>%Y)S",
-      "season_episode_from_date" => "s%(upload_date>%Y)Se%(upload_date>%m%d)S"
+      "season_episode_from_date" => "s%(upload_date>%Y)Se%(upload_date>%m%d)S",
+      "artist_name" => "%(artist,creator,uploader,uploader_id)S"
     }
   end
 end

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -39,7 +39,8 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       upload_year: nil,
       upload_yyyy_mm_dd: "the upload date in the format YYYY-MM-DD",
       source_custom_name: "the name of the sources that use this profile",
-      source_collection_type: "the collection type of the sources that use this profile. Either 'channel' or 'playlist'"
+      source_collection_type: "the collection type of the sources using this profile. Either 'channel' or 'playlist'",
+      artist_name: "the name of the artist with fallbacks to other uploader fields"
     }
   end
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -74,6 +74,6 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
   end
 
   defp audio_output_template do
-    "/music/{{ source_custom_name }}/{{ title }}.{{ ext }}"
+    "/music/{{ artist_name }}/{{ title }}.{{ ext }}"
   end
 end


### PR DESCRIPTION
## What's new?

- Adds `artist_name` custom output template placeholder
  - Getting the artist's name from `yt-dlp` can be tricky if the uploader hasn't tagged their video correctly. This new placeholder attempts to use the artist, but falls back to creator and then uploader if needed. It's better than what it was!

## What's changed?

- Updated the audio preset to use the new `artist_name` placeholder

## What's fixed?

N/A

## Any other comments?

N/A

