### PR TITLE
[Internal] Store source images in internal metadata

### DIFF
--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -12,6 +12,22 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   alias Pinchflat.Filesystem.FilesystemHelpers
 
   @doc """
+  Returns the directory where metadata for a database record should be stored.
+
+  Returns binary()
+  """
+  def metadata_directory_for(database_record) do
+    metadata_directory = Application.get_env(:pinchflat, :metadata_directory)
+    record_table_name = database_record.__meta__.source
+
+    Path.join([
+      metadata_directory,
+      record_table_name,
+      to_string(database_record.id)
+    ])
+  end
+
+  @doc """
   Compresses and stores metadata for a media item, returning the filepath.
 
   Returns binary()
@@ -108,13 +124,8 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   end
 
   defp generate_filepath_for(database_record, filename) do
-    metadata_directory = Application.get_env(:pinchflat, :metadata_directory)
-    record_table_name = database_record.__meta__.source
-
     Path.join([
-      metadata_directory,
-      record_table_name,
-      to_string(database_record.id),
+      metadata_directory_for(database_record),
       filename
     ])
   end

--- a/lib/pinchflat/metadata/source_metadata.ex
+++ b/lib/pinchflat/metadata/source_metadata.ex
@@ -10,11 +10,20 @@ defmodule Pinchflat.Metadata.SourceMetadata do
 
   alias Pinchflat.Sources.Source
 
-  @allowed_fields ~w(metadata_filepath)a
+  @allowed_fields ~w(
+    metadata_filepath
+    fanart_filepath
+    poster_filepath
+    banner_filepath
+  )a
+
   @required_fields ~w(metadata_filepath)a
 
   schema "source_metadata" do
     field :metadata_filepath, :string
+    field :fanart_filepath, :string
+    field :poster_filepath, :string
+    field :banner_filepath, :string
 
     belongs_to :source, Source
 
@@ -31,6 +40,11 @@ defmodule Pinchflat.Metadata.SourceMetadata do
 
   @doc false
   def filepath_attributes do
-    ~w(metadata_filepath)a
+    ~w(
+      metadata_filepath
+      fanart_filepath
+      poster_filepath
+      banner_filepath
+    )a
   end
 end

--- a/priv/repo/migrations/20240325174728_add_image_attrs_to_source_metadata.exs
+++ b/priv/repo/migrations/20240325174728_add_image_attrs_to_source_metadata.exs
@@ -1,0 +1,11 @@
+defmodule Pinchflat.Repo.Migrations.AddImageAttrsToSourceMetadata do
+  use Ecto.Migration
+
+  def change do
+    alter table(:source_metadata) do
+      add :fanart_filepath, :string
+      add :poster_filepath, :string
+      add :banner_filepath, :string
+    end
+  end
+end

--- a/test/pinchflat/metadata/metadata_file_helpers_test.exs
+++ b/test/pinchflat/metadata/metadata_file_helpers_test.exs
@@ -140,4 +140,14 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
       end
     end
   end
+
+  describe "metadata_directory_for/1" do
+    test "returns the metadata directory for the given record", %{media_item: media_item} do
+      base_metadata_directory = Application.get_env(:pinchflat, :metadata_directory)
+
+      metadata_directory = Helpers.metadata_directory_for(media_item)
+
+      assert metadata_directory == Path.join([base_metadata_directory, "media_items", "#{media_item.id}"])
+    end
+  end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Updates Source metadata worker to store source images in internal metadata directory (if present)

## What's fixed?

N/A

## Any other comments?

N/A

