### PR TITLE
[Internal] Removed old startup tasks

### DIFF
--- a/lib/pinchflat/boot/data_backfill_worker.ex
+++ b/lib/pinchflat/boot/data_backfill_worker.ex
@@ -18,7 +18,6 @@ defmodule Pinchflat.Boot.DataBackfillWorker do
 
   alias __MODULE__
   alias Pinchflat.Repo
-  alias Pinchflat.Media.MediaItem
 
   @doc """
   Cancels all pending backfill jobs. Useful for ensuring worker runs immediately
@@ -44,24 +43,12 @@ defmodule Pinchflat.Boot.DataBackfillWorker do
   """
   def perform(%Oban.Job{}) do
     Logger.info("Running data backfill worker")
-    backfill_shorts_data()
+    # Nothing to do for now - just reschedule
+    # Keeping in-place because we _will_ need it in the future
 
     reschedule_backfill()
 
     :ok
-  end
-
-  defp backfill_shorts_data do
-    query =
-      from(
-        m in MediaItem,
-        where: fragment("? like ?", m.original_url, "%/shorts/%"),
-        where: m.short_form_content == false
-      )
-
-    {count, _} = Repo.update_all(query, set: [short_form_content: true])
-
-    Logger.info("Backfill worker set short_form_content to true for #{count} media items.")
   end
 
   defp reschedule_backfill do

--- a/test/pinchflat/boot/data_backfill_worker_test.exs
+++ b/test/pinchflat/boot/data_backfill_worker_test.exs
@@ -1,8 +1,6 @@
 defmodule Pinchflat.Boot.DataBackfillWorkerTest do
   use Pinchflat.DataCase
 
-  import Pinchflat.MediaFixtures
-
   alias Pinchflat.Boot.DataBackfillWorker
   alias Pinchflat.JobFixtures.TestJobWorker
 
@@ -43,28 +41,6 @@ defmodule Pinchflat.Boot.DataBackfillWorkerTest do
       perform_job(DataBackfillWorker, %{})
 
       assert_enqueued(worker: DataBackfillWorker, scheduled_at: now_plus(60, :minutes))
-    end
-  end
-
-  describe "perform/1 when testing backfill_shorts_data" do
-    test "sets short_form_content to true for media items with shorts in the URL" do
-      media_item = media_item_with_attachments(%{original_url: "https://example.com/shorts/123"})
-
-      refute media_item.short_form_content
-
-      perform_job(DataBackfillWorker, %{})
-
-      assert Repo.reload!(media_item).short_form_content
-    end
-
-    test "does not set short_form_content to true for media items without shorts in the URL" do
-      media_item = media_item_with_attachments(%{original_url: "https://example.com/longs/123"})
-
-      refute media_item.short_form_content
-
-      perform_job(DataBackfillWorker, %{})
-
-      refute Repo.reload!(media_item).short_form_content
     end
   end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Removes some old startup tasks used to get data in the correct state. I don't know why I didn't write a migration in the first place, but here we are

## What's fixed?

N/A

## Any other comments?

N/A

