### PR TITLE
[Enhancement] Show total count of downloaded media on Source page

### DIFF
--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -88,7 +88,7 @@
       </:tab>
       <:tab title="Downloaded Media">
         <%= if match?([_|_], @downloaded_media) do %>
-          <h4 class="text-white text-lg mb-6">Shows a maximum of 100 media items</h4>
+          <h4 class="text-white text-lg mb-6">Shows a maximum of 100 media items (<%= @total_downloaded %> total)</h4>
           <.table rows={@downloaded_media} table_class="text-black dark:text-white">
             <:col :let={media_item} label="Title">
               <%= StringUtils.truncate(media_item.title, 50) %>


### PR DESCRIPTION
## What's new?

- Adds count of downloaded media to source show page (resolves #131)

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A
