### PR TITLE
[Triage] Allow changing SQLite journal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ You _must_ ensure the host directories you've mounted are writable by the user r
 
 It's recommended to not run the container as root. Doing so can create permission issues if other apps need to work with the downloaded media. If you need to run any command as root, you can run `su` from the container's shell as there is no password set for the root user.
 
+### Advanced: storing Pinchflat config directory on a network share
+
+README: This is currently in the testing phase and not a recommended option (yet). The implications of changing this setting isn't clear and this could, conceivably, result in data loss. Only change this setting if you know what you're doing, why this is important, and are okay with possible data loss or DB corruption. This may become the default in the future once it's been tested more thoroughly.
+
+As pointed out in [#137](https://github.com/kieraneglin/pinchflat/issues/137), SQLite doesn't like being run in WAL mode on network shares. If you're running Pinchflat on a network share, you can disable WAL mode by setting the `JOURNAL_MODE` environment variable to `delete`. This will make Pinchflat run in rollback journal mode which is less performant but should work on network shares.
+
+If you change this setting and it works well for you, please leave a comment on [#137](https://github.com/kieraneglin/pinchflat/issues/137)! Doubly so if it does _not_ work well.
+
 ## EFF donations
 
 A portion of all donations to Pinchflat will be donated to the [Electronic Frontier Foundation](https://www.eff.org/). The EFF defends your online liberties and [backed](https://github.com/github/dmca/blob/9a85e0f021f7967af80e186b890776a50443f06c/2020/11/2020-11-16-RIAA-reversal-effletter.pdf) `youtube-dl` when Google took them down. [See here](https://github.com/kieraneglin/pinchflat/wiki/EFF-Donation-Receipts) for a list of donation receipts.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Simply search for Pinchflat in the Community Apps store!
 
 ### Portainer
 
+Important: See the note belonw about storing config on a network file share. It's preferred to store the config on a local disk if at all possible.
+
 Docker Compose file:
 
 ```yaml

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,10 @@ config :pinchflat,
   expose_feed_endpoints: false,
   file_watcher_poll_interval: 1000
 
+config :pinchflat, Pinchflat.Repo,
+  journal_mode: :wal,
+  pool_size: 5
+
 # Configures the endpoint
 config :pinchflat, PinchflatWeb.Endpoint,
   url: [host: "localhost", port: 8945],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -50,16 +50,10 @@ if config_env() == :prod do
   # For running PF as a podcast host on self-hosted environments
   expose_feed_endpoints = String.length(System.get_env("EXPOSE_FEED_ENDPOINTS", "")) > 0
 
-  # We want to force _some_ level of useful logging in production
-  acceptable_log_levels = ~w(debug info)a
-  log_level = String.to_existing_atom(System.get_env("LOG_LEVEL", "info"))
+  # For testing alternate journal modes (see issue #137)
+  journal_mode = String.to_existing_atom(System.get_env("JOURNAL_MODE", "wal"))
 
-  if log_level in acceptable_log_levels do
-    config :logger, level: log_level
-  else
-    Logger.error("Invalid log level: #{log_level}. Defaulting to info.")
-    config :logger, level: :info
-  end
+  config :logger, level: String.to_existing_atom(System.get_env("LOG_LEVEL", "info"))
 
   config :pinchflat,
     yt_dlp_executable: System.find_executable("yt-dlp"),
@@ -72,7 +66,7 @@ if config_env() == :prod do
 
   config :pinchflat, Pinchflat.Repo,
     database: db_path,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
+    journal_mode: journal_mode
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,6 @@ config :pinchflat, Oban, testing: :manual
 # Run `mix help test` for more information.
 config :pinchflat, Pinchflat.Repo,
   database: Path.expand("../priv/repo/pinchflat_test.db", Path.dirname(__ENV__.file)),
-  pool_size: 5,
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,

--- a/lib/pinchflat/release.ex
+++ b/lib/pinchflat/release.ex
@@ -25,14 +25,15 @@ defmodule Pinchflat.Release do
   def check_file_permissions do
     load_app()
 
-    directories = [
-      "/config",
-      "/downloads",
-      Application.get_env(:pinchflat, :media_directory),
-      Application.get_env(:pinchflat, :tmpfile_directory),
-      Application.get_env(:pinchflat, :extras_directory),
-      Application.get_env(:pinchflat, :metadata_directory)
-    ]
+    directories =
+      Enum.uniq([
+        "/config",
+        "/downloads",
+        Application.get_env(:pinchflat, :media_directory),
+        Application.get_env(:pinchflat, :tmpfile_directory),
+        Application.get_env(:pinchflat, :extras_directory),
+        Application.get_env(:pinchflat, :metadata_directory)
+      ])
 
     Enum.each(directories, fn dir ->
       Logger.info("Checking permissions for #{dir}")


### PR DESCRIPTION
## What's new?

- Adds an ENV var to optionally change the SQLite journal mode in cases where the default of `wal` might not work (related to #137)

## What's changed?

- Cleans up `runtime.exs` and `release.ex` a little

## What's fixed?

N/A

## Any other comments?

N/A

