### PR TITLE
[Enhancement] Adds ability to stop media from re-downloading

### DIFF
--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -100,4 +100,14 @@ defmodule Pinchflat.Media.MediaItem do
   def filepath_attributes do
     ~w(media_filepath thumbnail_filepath metadata_filepath subtitle_filepaths nfo_filepath)a
   end
+
+  @doc false
+  def filepath_attribute_defaults do
+    filepath_attributes()
+    |> Enum.map(fn
+      :subtitle_filepaths -> {:subtitle_filepaths, []}
+      field -> {field, nil}
+    end)
+    |> Enum.into(%{})
+  end
 end

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -30,7 +30,9 @@ defmodule Pinchflat.Media.MediaItem do
     :subtitle_filepaths,
     :thumbnail_filepath,
     :metadata_filepath,
-    :nfo_filepath
+    :nfo_filepath,
+    # These are user or system controlled fields
+    :prevent_download
   ]
   # Pretty much all the fields captured at index are required.
   @required_fields ~w(
@@ -69,6 +71,8 @@ defmodule Pinchflat.Media.MediaItem do
     # be an associated record, but I don't see the benefit right now.
     # Will very likely revisit because I can't leave well-enough alone.
     field :subtitle_filepaths, {:array, {:array, :string}}, default: []
+
+    field :prevent_download, :boolean, default: false
 
     field :matching_search_term, :string, virtual: true
 

--- a/lib/pinchflat/media/media_query.ex
+++ b/lib/pinchflat/media/media_query.ex
@@ -53,6 +53,10 @@ defmodule Pinchflat.Media.MediaQuery do
     where(query, [mi], mi.upload_date >= ^date)
   end
 
+  def with_no_prevented_download(query) do
+    where(query, [mi], mi.prevent_download == false)
+  end
+
   def matching_title_regex(query, nil), do: query
 
   def matching_title_regex(query, regex) do

--- a/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
@@ -17,19 +17,12 @@ defmodule PinchflatWeb.MediaItems.MediaItemController do
   end
 
   def delete(conn, %{"id" => id} = params) do
-    delete_files = Map.get(params, "delete_files", false)
+    prevent_download = Map.get(params, "prevent_download", false)
     media_item = Media.get_media_item!(id)
-    {:ok, _} = Media.delete_media_item(media_item, delete_files: delete_files)
-
-    flash_message =
-      if delete_files do
-        "Record and files deleted successfully."
-      else
-        "Record deleted successfully. Files were not deleted."
-      end
+    {:ok, _} = Media.delete_media_files(media_item, prevent_download: prevent_download)
 
     conn
-    |> put_flash(:info, flash_message)
+    |> put_flash(:info, "Files deleted successfully.")
     |> redirect(to: ~p"/sources/#{media_item.source_id}")
   end
 

--- a/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
@@ -16,6 +16,27 @@ defmodule PinchflatWeb.MediaItems.MediaItemController do
     render(conn, :show, media_item: media_item)
   end
 
+  def edit(conn, %{"id" => id}) do
+    media_item = Media.get_media_item!(id)
+    changeset = Media.change_media_item(media_item)
+
+    render(conn, :edit, media_item: media_item, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "media_item" => params}) do
+    media_item = Media.get_media_item!(id)
+
+    case Media.update_media_item(media_item, params) do
+      {:ok, media_item} ->
+        conn
+        |> put_flash(:info, "Media Item updated successfully.")
+        |> redirect(to: ~p"/sources/#{media_item.source_id}/media/#{media_item}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :edit, media_item: media_item, changeset: changeset)
+    end
+  end
+
   def delete(conn, %{"id" => id} = params) do
     prevent_download = Map.get(params, "prevent_download", false)
     media_item = Media.get_media_item!(id)

--- a/lib/pinchflat_web/controllers/media_items/media_item_html.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html.ex
@@ -3,6 +3,14 @@ defmodule PinchflatWeb.MediaItems.MediaItemHTML do
 
   embed_templates "media_item_html/*"
 
+  @doc """
+  Renders a media item form.
+  """
+  attr :changeset, Ecto.Changeset, required: true
+  attr :action, :string, required: true
+
+  def media_item_form(assigns)
+
   def media_file_exists?(media_item) do
     !!media_item.media_filepath and File.exists?(media_item.media_filepath)
   end

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/edit.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/edit.html.heex
@@ -1,0 +1,13 @@
+<div class="mb-6 flex gap-3 flex-row items-center">
+  <h2 class="text-title-md2 font-bold text-black dark:text-white ml-4">
+    Editing "<%= StringUtils.truncate(@media_item.title, 35) %>"
+  </h2>
+</div>
+
+<div class="rounded-sm border border-stroke bg-white px-5 pb-2.5 pt-6 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 xl:pb-1">
+  <div class="max-w-full overflow-x-auto">
+    <div class="flex flex-col gap-10">
+      <.media_item_form changeset={@changeset} action={~p"/sources/#{@media_item.source_id}/media/#{@media_item}"} />
+    </div>
+  </div>
+</div>

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
@@ -1,0 +1,24 @@
+<.simple_form
+  :let={f}
+  for={@changeset}
+  action={@action}
+  x-data="{ advancedMode: !!JSON.parse(localStorage.getItem('advancedMode')) }"
+  x-init="$watch('advancedMode', value => localStorage.setItem('advancedMode', JSON.stringify(value)))"
+>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+
+  <h3 class=" text-2xl text-black dark:text-white">
+    General Options
+  </h3>
+
+  <.input
+    field={f[:prevent_download]}
+    type="toggle"
+    label="Prevent Download"
+    help="Checking excludes this media item from being downloaded"
+  />
+
+  <.button class="my-10 sm:mb-7.5 w-full sm:w-auto" rounding="rounded-lg">Save Media Item</.button>
+</.simple_form>

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
@@ -4,7 +4,7 @@
       <.icon name="hero-arrow-left" class="w-10 h-10 hover:dark:text-white" />
     </.link>
     <h2 class="text-title-md2 font-bold text-black dark:text-white ml-4">
-      Media Item #<%= @media_item.id %>
+      <%= StringUtils.truncate(@media_item.title, 35) %>
     </h2>
   </div>
 </div>
@@ -15,11 +15,20 @@
         <.button_dropdown text="Actions" class="justify-center w-full sm:w-50">
           <:option>
             <.link
-              href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}?delete_files=true"}
+              href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}"}
               method="delete"
-              data-confirm="Are you sure you want to delete this record and all associated files on disk? This cannot be undone."
+              data-confirm="Are you sure you want to delete all files for this media item? This cannot be undone."
             >
               Delete Files
+            </.link>
+          </:option>
+          <:option>
+            <.link
+              href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}?prevent_download=true"}
+              method="delete"
+              data-confirm="Are you sure you want to delete all files for this media item and prevent it from re-downloading in the future? This cannot be undone."
+            >
+              Delete and Ignore
             </.link>
           </:option>
         </.button_dropdown>
@@ -32,6 +41,7 @@
             <.media_preview media_item={@media_item} />
           <% end %>
 
+          <h2 class="font-bold text-2xl"><%= @media_item.title %></h2>
           <h3 class="font-bold text-xl">Attributes</h3>
           <section>
             <strong>Source:</strong>

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
@@ -7,6 +7,14 @@
       <%= StringUtils.truncate(@media_item.title, 35) %>
     </h2>
   </div>
+
+  <nav>
+    <.link href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}/edit"}>
+      <.button color="bg-primary" rounding="rounded-lg">
+        <.icon name="hero-pencil-square" class="mr-2" /> Edit
+      </.button>
+    </.link>
+  </nav>
 </div>
 <div class="rounded-sm border border-stroke bg-white py-5 pt-6 shadow-default dark:border-strokedark dark:bg-boxdark px-7.5">
   <div class="max-w-full overflow-x-auto">

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -32,7 +32,7 @@ defmodule PinchflatWeb.Router do
     resources "/search", Searches.SearchController, only: [:show], singleton: true
 
     resources "/sources", Sources.SourceController do
-      resources "/media", MediaItems.MediaItemController, only: [:show, :delete]
+      resources "/media", MediaItems.MediaItemController, only: [:show, :edit, :update, :delete]
     end
   end
 

--- a/priv/repo/migrations/20240402192417_add_prevent_download_to_media_items.exs
+++ b/priv/repo/migrations/20240402192417_add_prevent_download_to_media_items.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddPreventDownloadToMediaItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_items) do
+      add :prevent_download, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/pinchflat_web/controllers/media_item_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_item_controller_test.exs
@@ -15,6 +15,36 @@ defmodule PinchflatWeb.MediaItemControllerTest do
     end
   end
 
+  describe "edit media" do
+    setup [:create_media_item]
+
+    test "renders form for editing chosen media_item", %{conn: conn, media_item: media_item} do
+      conn = get(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item}/edit")
+
+      assert html_response(conn, 200) =~ "Editing"
+    end
+  end
+
+  describe "update media" do
+    setup [:create_media_item]
+
+    test "redirects when data is valid", %{conn: conn, media_item: media_item} do
+      update_attrs = %{title: "New Title"}
+
+      conn = put(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item}", media_item: update_attrs)
+      assert redirected_to(conn) == ~p"/sources/#{media_item.source_id}/media/#{media_item}"
+
+      conn = get(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item}")
+      assert html_response(conn, 200) =~ update_attrs[:title]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, media_item: media_item} do
+      conn = put(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item}", media_item: %{title: nil})
+
+      assert html_response(conn, 200) =~ "Editing"
+    end
+  end
+
   describe "delete media" do
     setup do
       media_item = media_item_with_attachments()


### PR DESCRIPTION
## What's new?

- Adds `prevent_download` column to media item that stops a media item from being downloaded (or re-downloaded)
- Adds edit/update controller actions and UI for media items

## What's changed?

- Update MI deletion via UI to delete the files but retain the database record

## What's fixed?

N/A

## Any other comments?

N/A

