### PR TITLE
[Enhancement] Allow manual indexing/downloading

### DIFF
--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -27,12 +27,12 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
 
   Returns {:ok, %Task{}}.
   """
-  def kickoff_indexing_task(%Source{} = source) do
+  def kickoff_indexing_task(%Source{} = source, job_args \\ %{}, job_opts \\ []) do
     Tasks.delete_pending_tasks_for(source, "FastIndexingWorker")
     Tasks.delete_pending_tasks_for(source, "MediaIndexingWorker")
     Tasks.delete_pending_tasks_for(source, "MediaCollectionIndexingWorker")
 
-    MediaCollectionIndexingWorker.kickoff_with_task(source)
+    MediaCollectionIndexingWorker.kickoff_with_task(source, job_args, job_opts)
   end
 
   @doc """

--- a/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
@@ -6,6 +6,7 @@ defmodule PinchflatWeb.MediaItems.MediaItemController do
   alias Pinchflat.Repo
   alias Pinchflat.Media
   alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Downloading.MediaDownloadWorker
 
   def show(conn, %{"id" => id}) do
     media_item =
@@ -45,6 +46,15 @@ defmodule PinchflatWeb.MediaItems.MediaItemController do
     conn
     |> put_flash(:info, "Files deleted successfully.")
     |> redirect(to: ~p"/sources/#{media_item.source_id}")
+  end
+
+  def force_download(conn, %{"media_item_id" => id}) do
+    media_item = Media.get_media_item!(id)
+    {:ok, _} = MediaDownloadWorker.kickoff_with_task(media_item, %{force: true})
+
+    conn
+    |> put_flash(:info, "Download task enqueued.")
+    |> redirect(to: ~p"/sources/#{media_item.source_id}/media/#{media_item}")
   end
 
   # See here for details on streaming files and range requests:

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/actions_dropdown.html.heex
@@ -1,0 +1,32 @@
+<.button_dropdown text="Actions" class="justify-center w-full sm:w-50">
+  <:option>
+    <.link
+      href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}/force_download"}
+      method="post"
+      data-confirm="Are you sure you force a download of this media?"
+    >
+      Force Download
+    </.link>
+  </:option>
+  <:option>
+    <div class="h-px w-full bg-bodydark2"></div>
+  </:option>
+  <:option>
+    <.link
+      href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}"}
+      method="delete"
+      data-confirm="Are you sure you want to delete all files for this media item? This cannot be undone."
+    >
+      Delete Files
+    </.link>
+  </:option>
+  <:option>
+    <.link
+      href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}?prevent_download=true"}
+      method="delete"
+      data-confirm="Are you sure you want to delete all files for this media item and prevent it from re-downloading in the future? This cannot be undone."
+    >
+      Delete and Ignore
+    </.link>
+  </:option>
+</.button_dropdown>

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
@@ -17,7 +17,7 @@
     field={f[:prevent_download]}
     type="toggle"
     label="Prevent Download"
-    help="Checking excludes this media item from being downloaded"
+    help="Checking excludes this media item from automatic download. Download can still be manually forced"
   />
 
   <.input

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
@@ -20,26 +20,7 @@
   <div class="max-w-full overflow-x-auto">
     <.tabbed_layout>
       <:tab_append>
-        <.button_dropdown text="Actions" class="justify-center w-full sm:w-50">
-          <:option>
-            <.link
-              href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}"}
-              method="delete"
-              data-confirm="Are you sure you want to delete all files for this media item? This cannot be undone."
-            >
-              Delete Files
-            </.link>
-          </:option>
-          <:option>
-            <.link
-              href={~p"/sources/#{@media_item.source_id}/media/#{@media_item}?prevent_download=true"}
-              method="delete"
-              data-confirm="Are you sure you want to delete all files for this media item and prevent it from re-downloading in the future? This cannot be undone."
-            >
-              Delete and Ignore
-            </.link>
-          </:option>
-        </.button_dropdown>
+        <.actions_dropdown media_item={@media_item} />
       </:tab_append>
 
       <:tab title="Attributes">
@@ -53,9 +34,9 @@
           <h3 class="font-bold text-xl">Attributes</h3>
           <section>
             <strong>Source:</strong>
-            <.inline_link href={~p"/sources/#{@media_item.source_id}"}>
+            <.subtle_link href={~p"/sources/#{@media_item.source_id}"}>
               <%= @media_item.source.custom_name %>
-            </.inline_link>
+            </.subtle_link>
           </section>
 
           <.list_items_from_map map={Map.from_struct(@media_item)} />

--- a/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
@@ -16,7 +16,7 @@
     <.link
       href={~p"/sources/#{@source}/force_download"}
       method="post"
-      data-confirm="Are you sure you force a download of all *pending* media items? This isn't normally needed."
+      data-confirm="Are you sure you want to force a download of all *pending* media items? This isn't normally needed."
     >
       Force Download
     </.link>
@@ -25,7 +25,7 @@
     <.link
       href={~p"/sources/#{@source}/force_index"}
       method="post"
-      data-confirm="Are you sure you force an index of this source? This isn't normally needed."
+      data-confirm="Are you sure you want to force an index of this source? This isn't normally needed."
     >
       Force Index
     </.link>

--- a/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
@@ -1,0 +1,55 @@
+<.button_dropdown text="Actions" class="justify-center w-full sm:w-50">
+  <:option>
+    <span
+      x-data="{ copied: false }"
+      x-on:click={"
+                window.copyTextToClipboard('#{rss_feed_url(@conn, @source)}')
+                copied = true
+                setTimeout(() => copied = false, 4000)
+              "}
+    >
+      Copy RSS Feed
+      <span x-show="copied" x-transition.duration.150ms><.icon name="hero-check" class="ml-2 h-4 w-4" /></span>
+    </span>
+  </:option>
+  <:option :if={@source.download_media}>
+    <.link
+      href={~p"/sources/#{@source}/force_download"}
+      method="post"
+      data-confirm="Are you sure you force a download of all *pending* media items? This isn't normally needed."
+    >
+      Force Download
+    </.link>
+  </:option>
+  <:option>
+    <.link
+      href={~p"/sources/#{@source}/force_index"}
+      method="post"
+      data-confirm="Are you sure you force an index of this source? This isn't normally needed."
+    >
+      Force Index
+    </.link>
+  </:option>
+  <:option>
+    <div class="h-px w-full bg-bodydark2"></div>
+  </:option>
+  <:option>
+    <.link
+      href={~p"/sources/#{@source}"}
+      method="delete"
+      data-confirm="Are you sure you want to delete this source (leaving files in place)? This cannot be undone."
+    >
+      Delete Source
+    </.link>
+  </:option>
+  <:option>
+    <.link
+      href={~p"/sources/#{@source}?delete_files=true"}
+      method="delete"
+      data-confirm="Are you sure you want to delete this source and it's files on disk? This cannot be undone."
+      class="mt-5 md:mt-0"
+    >
+      Delete Source + Files
+    </.link>
+  </:option>
+</.button_dropdown>

--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -28,9 +28,9 @@
           <h3 class="font-bold text-lg">Attributes</h3>
           <section>
             <strong>Media Profile:</strong>
-            <.inline_link href={~p"/media_profiles/#{@source.media_profile_id}"}>
+            <.subtle_link href={~p"/media_profiles/#{@source.media_profile_id}"}>
               <%= @source.media_profile.name %>
-            </.inline_link>
+            </.subtle_link>
           </section>
 
           <.list_items_from_map map={Map.from_struct(@source)} />

--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -20,43 +20,7 @@
   <div class="max-w-full overflow-x-auto">
     <.tabbed_layout>
       <:tab_append>
-        <.button_dropdown text="Actions" class="justify-center w-full sm:w-50">
-          <:option>
-            <span
-              x-data="{ copied: false }"
-              x-on:click={"
-                window.copyTextToClipboard('#{rss_feed_url(@conn, @source)}')
-                copied = true
-                setTimeout(() => copied = false, 4000)
-              "}
-            >
-              Copy RSS Feed
-              <span x-show="copied" x-transition.duration.150ms><.icon name="hero-check" class="ml-2 h-4 w-4" /></span>
-            </span>
-          </:option>
-          <:option>
-            <div class="h-px w-full bg-bodydark2"></div>
-          </:option>
-          <:option>
-            <.link
-              href={~p"/sources/#{@source}"}
-              method="delete"
-              data-confirm="Are you sure you want to delete this source (leaving files in place)? This cannot be undone."
-            >
-              Delete Source
-            </.link>
-          </:option>
-          <:option>
-            <.link
-              href={~p"/sources/#{@source}?delete_files=true"}
-              method="delete"
-              data-confirm="Are you sure you want to delete this source and it's files on disk? This cannot be undone."
-              class="mt-5 md:mt-0"
-            >
-              Delete Source + Files
-            </.link>
-          </:option>
-        </.button_dropdown>
+        <.actions_dropdown source={@source} conn={@conn} />
       </:tab_append>
 
       <:tab title="Attributes">

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -32,6 +32,9 @@ defmodule PinchflatWeb.Router do
     resources "/search", Searches.SearchController, only: [:show], singleton: true
 
     resources "/sources", Sources.SourceController do
+      post "/force_download", Sources.SourceController, :force_download
+      post "/force_index", Sources.SourceController, :force_index
+
       resources "/media", MediaItems.MediaItemController, only: [:show, :edit, :update, :delete]
     end
   end

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -35,7 +35,9 @@ defmodule PinchflatWeb.Router do
       post "/force_download", Sources.SourceController, :force_download
       post "/force_index", Sources.SourceController, :force_index
 
-      resources "/media", MediaItems.MediaItemController, only: [:show, :edit, :update, :delete]
+      resources "/media", MediaItems.MediaItemController, only: [:show, :edit, :update, :delete] do
+        post "/force_download", MediaItems.MediaItemController, :force_download
+      end
     end
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,8 +21,10 @@ defmodule PinchflatWeb.ConnCase do
     quote do
       # The default endpoint for testing
       @endpoint PinchflatWeb.Endpoint
+      alias Pinchflat.Repo
 
       use PinchflatWeb, :verified_routes
+      use Oban.Testing, repo: Repo
 
       # Import conveniences for testing with connections
       import Plug.Conn


### PR DESCRIPTION
## What's new?

- Updates source workers, controllers, and UI to allow forcing a re-index or downloading of pending items
- Updates media item workers, controllers, and UI to allow forcing download of an item

## What's changed?

- Indexing and downloading workers now accept a `force` arg to run their task even when they otherwise wouldn't
- Refactored dropdowns into their own components

## What's fixed?

N/A

## Any other comments?

N/A

