### PR TITLE
[Enhancement] Add more source options to output templates

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -144,6 +144,8 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   defp output_options_map(source) do
     %{
       "source_custom_name" => source.custom_name,
+      "source_collection_id" => source.collection_id,
+      "source_collection_name" => source.collection_name,
       "source_collection_type" => source.collection_type
     }
   end

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -59,6 +59,9 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       upload_year: nil,
       upload_yyyy_mm_dd: "the upload date in the format YYYY-MM-DD",
       source_custom_name: "the name of the sources that use this profile",
+      source_collection_id: "the YouTube ID of the sources that use this profile",
+      source_collection_name:
+        "the YouTube name of the sources that use this profile (often the same as source_custom_name)",
       source_collection_type: "the collection type of the sources using this profile. Either 'channel' or 'playlist'",
       artist_name: "the name of the artist with fallbacks to other uploader fields"
     }


### PR DESCRIPTION
## What's new?

- Adds `source_collection_id` and `source_collection_name` as custom output template options (related to #171)

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

