### PR TITLE
[Enhancement] Redownload new media after a delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If it doesn't work for your use case, please make a feature request! You can als
 - Supports downloading audio content
 - Custom rules for handling YouTube Shorts and livestreams
 - Apprise support for notifications
+- Allows automatically redownloading new media after a set period
+  - This can help improve the download quality of new content or improve SponsorBlock tags
 - Optionally automatically delete old content ([docs](https://github.com/kieraneglin/pinchflat/wiki/Automatically-Delete-Media))
 - Advanced options like setting cutoff dates and filtering by title
 - Reliable hands-off operation

--- a/config/config.exs
+++ b/config/config.exs
@@ -52,7 +52,8 @@ config :pinchflat, Oban,
     {Oban.Plugins.Pruner, max_age: 30 * 24 * 60 * 60},
     {Oban.Plugins.Cron,
      crontab: [
-       {"@daily", Pinchflat.Downloading.MediaRetentionWorker}
+       {"0 1 * * *", Pinchflat.Downloading.MediaRetentionWorker},
+       {"0 2 * * *", Pinchflat.Downloading.MediaRedownloadWorker}
      ]}
   ],
   # TODO: consider making this an env var or something?

--- a/lib/pinchflat/downloading/media_redownload_worker.ex
+++ b/lib/pinchflat/downloading/media_redownload_worker.ex
@@ -9,11 +9,23 @@ defmodule Pinchflat.Downloading.MediaRedownloadWorker do
   require Logger
 
   alias Pinchflat.Media
+  alias Pinchflat.Downloading.MediaDownloadWorker
 
   @doc """
+  Redownloads media items that are eligible for redownload.
+
+  This worker is scheduled to run daily via the Oban Cron plugin
+  and it should run _after_ the retention worker.
+
+  Returns :ok
   """
-  # TODO
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
+    redownloadable_media = Media.list_redownloadable_media_items()
+    Logger.info("Redownloading #{length(redownloadable_media)} media items")
+
+    Enum.each(redownloadable_media, fn media_item ->
+      MediaDownloadWorker.kickoff_with_task(media_item, %{redownload?: true})
+    end)
   end
 end

--- a/lib/pinchflat/downloading/media_redownload_worker.ex
+++ b/lib/pinchflat/downloading/media_redownload_worker.ex
@@ -1,0 +1,19 @@
+defmodule Pinchflat.Downloading.MediaRedownloadWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :media_fetching,
+    unique: [period: :infinity, states: [:available, :scheduled, :retryable, :executing]],
+    tags: ["media_item", "media_fetching"]
+
+  require Logger
+
+  alias Pinchflat.Media
+
+  @doc """
+  """
+  # TODO
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+  end
+end

--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -40,11 +40,19 @@ defmodule Pinchflat.Media do
   Returns a list of media_items that are redownloadable based on the redownload delay
   of the media_profile their source belongs to.
 
+  The logic is that a media_item is past_redownload_delay if the media_item's
+  upload_date is at least redownload_delay_days ago AND
+  `media_downloaded_at` - `redownload_delay_days` is before the media_item's `upload_date`.
+  This logic grabs media that we've recently downloaded AND is recently uploaded, but
+  doesn't grab media that we've recently downloaded and was uploaded a long time ago.
+  This also makes things work as expected when downloading media from a source for the
+  first time.
+
   Returns [%MediaItem{}, ...]
   """
   def list_redownloadable_media_items do
     MediaQuery.new()
-    |> MediaQuery.with_media_filepath()
+    |> MediaQuery.with_media_downloaded_at()
     |> MediaQuery.where_download_not_prevented()
     |> MediaQuery.where_not_culled()
     |> MediaQuery.where_media_not_redownloaded()

--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -31,15 +31,31 @@ defmodule Pinchflat.Media do
   def list_cullable_media_items do
     MediaQuery.new()
     |> MediaQuery.with_media_filepath()
-    |> MediaQuery.with_passed_retention_period()
-    |> MediaQuery.with_no_culling_prevention()
+    |> MediaQuery.where_past_retention_period()
+    |> MediaQuery.where_culling_not_prevented()
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns a list of media_items that are redownloadable based on the redownload delay
+  of the media_profile their source belongs to.
+
+  Returns [%MediaItem{}, ...]
+  """
+  def list_redownloadable_media_items do
+    MediaQuery.new()
+    |> MediaQuery.with_media_filepath()
+    |> MediaQuery.where_download_not_prevented()
+    |> MediaQuery.where_not_culled()
+    |> MediaQuery.where_media_not_redownloaded()
+    |> MediaQuery.where_past_redownload_delay()
     |> Repo.all()
   end
 
   @doc """
   Returns a list of pending media_items for a given source, where
   pending means the `media_filepath` is `nil` AND the media_item
-  matches satisfies `MediaQuery.with_media_pending_download`. You
+  matches satisfies `MediaQuery.where_pending_download`. You
   should really check out that function if you need to know more
   because it has a lot going on.
 
@@ -48,7 +64,7 @@ defmodule Pinchflat.Media do
   def list_pending_media_items_for(%Source{} = source) do
     MediaQuery.new()
     |> MediaQuery.for_source(source)
-    |> MediaQuery.with_media_pending_download()
+    |> MediaQuery.where_pending_download()
     |> Repo.all()
   end
 
@@ -66,7 +82,7 @@ defmodule Pinchflat.Media do
 
     MediaQuery.new()
     |> MediaQuery.with_id(media_item.id)
-    |> MediaQuery.with_media_pending_download()
+    |> MediaQuery.where_pending_download()
     |> Repo.exists?()
   end
 

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -34,7 +34,8 @@ defmodule Pinchflat.Media.MediaItem do
     # These are user or system controlled fields
     :prevent_download,
     :prevent_culling,
-    :culled_at
+    :culled_at,
+    :redownloaded_at
   ]
   # Pretty much all the fields captured at index are required.
   @required_fields ~w(
@@ -77,6 +78,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :prevent_download, :boolean, default: false
     field :prevent_culling, :boolean, default: false
     field :culled_at, :utc_datetime
+    field :redownloaded_at, :utc_datetime
 
     field :matching_search_term, :string, virtual: true
 

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -35,7 +35,7 @@ defmodule Pinchflat.Media.MediaItem do
     :prevent_download,
     :prevent_culling,
     :culled_at,
-    :redownloaded_at
+    :media_redownloaded_at
   ]
   # Pretty much all the fields captured at index are required.
   @required_fields ~w(
@@ -62,6 +62,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :livestream, :boolean, default: false
     field :short_form_content, :boolean, default: false
     field :media_downloaded_at, :utc_datetime
+    field :media_redownloaded_at, :utc_datetime
     field :upload_date, :date
     field :duration_seconds, :integer
 
@@ -78,7 +79,6 @@ defmodule Pinchflat.Media.MediaItem do
     field :prevent_download, :boolean, default: false
     field :prevent_culling, :boolean, default: false
     field :culled_at, :utc_datetime
-    field :redownloaded_at, :utc_datetime
 
     field :matching_search_term, :string, virtual: true
 

--- a/lib/pinchflat/notifications/source_notifications.ex
+++ b/lib/pinchflat/notifications/source_notifications.ex
@@ -59,7 +59,7 @@ defmodule Pinchflat.Notifications.SourceNotifications do
   defp pending_media_item_count(source) do
     MediaQuery.new()
     |> MediaQuery.for_source(source)
-    |> MediaQuery.with_media_pending_download()
+    |> MediaQuery.where_pending_download()
     |> Repo.aggregate(:count)
   end
 

--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -26,12 +26,14 @@ defmodule Pinchflat.Profiles.MediaProfile do
     shorts_behaviour
     livestream_behaviour
     preferred_resolution
+    redownload_delay_days
   )a
 
   @required_fields ~w(name output_path_template)a
 
   schema "media_profiles" do
     field :name, :string
+    field :redownload_delay_days, :integer
 
     field :output_path_template, :string,
       default: "/{{ source_custom_name }}/{{ upload_yyyy_mm_dd }} {{ title }}/{{ title }} [{{ id }}].{{ ext }}"
@@ -60,7 +62,6 @@ defmodule Pinchflat.Profiles.MediaProfile do
     # See `build_format_clauses` in the Media context for more.
     field :shorts_behaviour, Ecto.Enum, values: ~w(include exclude only)a, default: :include
     field :livestream_behaviour, Ecto.Enum, values: ~w(include exclude only)a, default: :include
-
     field :preferred_resolution, Ecto.Enum, values: ~w(2160p 1080p 720p 480p 360p audio)a, default: :"1080p"
 
     has_many :sources, Source
@@ -75,6 +76,7 @@ defmodule Pinchflat.Profiles.MediaProfile do
     |> validate_required(@required_fields)
     # Ensures it ends with `.{{ ext }}` or `.%(ext)s` or similar (with a little wiggle room)
     |> validate_format(:output_path_template, ext_regex(), message: "must end with .{{ ext }}")
+    |> validate_number(:redownload_delay_days, greater_than_or_equal_to: 0)
     |> unique_constraint(:name)
   end
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -203,6 +203,17 @@
       />
     </section>
 
+    <section x-data="{ presets: { default: null, media_center: 1, audio: null, archiving: 1 } }">
+      <.input
+        field={f[:redownload_delay_days]}
+        type="number"
+        label="Redownload Delay (days)"
+        min="0"
+        help="Delay in days until new media is redownloaded. Redownloading new media can improve its quality or SponsorBlock tags. Leave blank to not redownload"
+        x-init="$watch('selectedPreset', p => p && ($el.value = presets[p]))"
+      />
+    </section>
+
     <h3 class="mt-8 text-2xl text-black dark:text-white">
       Media Center Options
     </h3>

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -63,7 +63,7 @@ defmodule PinchflatWeb.Sources.SourceController do
     pending_media =
       MediaQuery.new()
       |> MediaQuery.for_source(source)
-      |> MediaQuery.with_media_pending_download()
+      |> MediaQuery.where_pending_download()
       |> order_by(desc: :id)
       |> limit(100)
       |> Repo.all()

--- a/priv/repo/migrations/20240409224152_add_redownloaded_fields.exs
+++ b/priv/repo/migrations/20240409224152_add_redownloaded_fields.exs
@@ -1,0 +1,13 @@
+defmodule Pinchflat.Repo.Migrations.AddRedownloadedFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_profiles) do
+      add :redownload_delay_days, :integer
+    end
+
+    alter table(:media_items) do
+      add :redownloaded_at, :utc_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20240409224152_add_redownloaded_fields.exs
+++ b/priv/repo/migrations/20240409224152_add_redownloaded_fields.exs
@@ -7,7 +7,7 @@ defmodule Pinchflat.Repo.Migrations.AddRedownloadedFields do
     end
 
     alter table(:media_items) do
-      add :redownloaded_at, :utc_datetime
+      add :media_redownloaded_at, :utc_datetime
     end
   end
 end

--- a/test/pinchflat/downloading/media_redownload_worker_test.exs
+++ b/test/pinchflat/downloading/media_redownload_worker_test.exs
@@ -1,0 +1,44 @@
+defmodule Pinchflat.Downloading.MediaRedownloadWorkerTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+  import Pinchflat.SourcesFixtures
+  import Pinchflat.ProfilesFixtures
+
+  alias Pinchflat.Downloading.MediaDownloadWorker
+  alias Pinchflat.Downloading.MediaRedownloadWorker
+
+  describe "perform/1" do
+    test "kicks off a task for redownloadable media items" do
+      media_profile = media_profile_fixture(%{redownload_delay_days: 4})
+      source = source_fixture(%{media_profile_id: media_profile.id, inserted_at: now_minus(10, :days)})
+
+      media_item =
+        media_item_fixture(%{
+          source_id: source.id,
+          upload_date: now_minus(6, :days),
+          media_downloaded_at: now_minus(5, :days)
+        })
+
+      perform_job(MediaRedownloadWorker, %{})
+
+      assert [_] = all_enqueued(worker: MediaDownloadWorker, args: %{id: media_item.id, redownload?: true})
+    end
+
+    test "does not kickoff a task for non-redownloadable media items" do
+      media_profile = media_profile_fixture(%{redownload_delay_days: 4})
+      source = source_fixture(%{media_profile_id: media_profile.id, inserted_at: now_minus(10, :days)})
+
+      _media_item =
+        media_item_fixture(%{
+          source_id: source.id,
+          upload_date: now_minus(6, :days),
+          media_downloaded_at: now_minus(1, :day)
+        })
+
+      perform_job(MediaRedownloadWorker, %{})
+
+      assert [] = all_enqueued(worker: MediaDownloadWorker)
+    end
+  end
+end


### PR DESCRIPTION
## What's new?

- Adds UI, columns, and workers to allow re-downloading new media after a set delay. This can help improve download quality or sponsorblock segments (resolves #127)

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

