### PR TITLE
[Enhancement] Allow custom yt-dlp options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If it doesn't work for your use case, please make a feature request! You can als
 - Reliable hands-off operation
 - Can pass cookies to YouTube to download your private playlists ([docs](https://github.com/kieraneglin/pinchflat/wiki/YouTube-Cookies))
 - Sponsorblock integration
+- \[Advanced\] allows custom `yt-dlp` options ([docs](https://github.com/kieraneglin/pinchflat/wiki/%5BAdvanced%5D-Custom-yt%E2%80%90dlp-options))
 
 ## Screenshots
 

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -32,7 +32,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   @impl true
   def init(state) do
     reset_executing_jobs()
-    create_blank_cookie_file()
+    create_blank_yt_dlp_files()
     apply_default_settings()
 
     {:ok, state}
@@ -50,15 +50,19 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
     Logger.info("Reset #{count} executing jobs")
   end
 
-  defp create_blank_cookie_file do
+  defp create_blank_yt_dlp_files do
+    files = ["cookies.txt", "yt-dlp-config.txt"]
     base_dir = Application.get_env(:pinchflat, :extras_directory)
-    filepath = Path.join(base_dir, "cookies.txt")
 
-    if !File.exists?(filepath) do
-      Logger.info("yt-dlp cookie file does not exist - creating it")
+    Enum.each(files, fn file ->
+      filepath = Path.join(base_dir, file)
 
-      FilesystemUtils.write_p!(filepath, "")
-    end
+      if !File.exists?(filepath) do
+        Logger.info("Creating blank file: #{filepath}")
+
+        FilesystemUtils.write_p!(filepath, "")
+      end
+    end)
   end
 
   defp apply_default_settings do

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -51,7 +51,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   end
 
   defp create_blank_yt_dlp_files do
-    files = ["cookies.txt", "yt-dlp-config.txt"]
+    files = ["cookies.txt", "yt-dlp-configs/main.txt"]
     base_dir = Application.get_env(:pinchflat, :extras_directory)
 
     Enum.each(files, fn file ->

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -51,7 +51,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   end
 
   defp create_blank_yt_dlp_files do
-    files = ["cookies.txt", "yt-dlp-configs/main.txt"]
+    files = ["cookies.txt", "yt-dlp-configs/base-config.txt"]
     base_dir = Application.get_env(:pinchflat, :extras_directory)
 
     Enum.each(files, fn file ->

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -76,11 +76,7 @@ defmodule Pinchflat.YtDlp.CommandRunner do
 
   defp build_external_file_options do
     base_dir = Application.get_env(:pinchflat, :extras_directory)
-
-    filename_options_map = %{
-      cookies: "cookies.txt",
-      config_locations: "yt-dlp-configs/main.txt"
-    }
+    filename_options_map = %{cookies: "cookies.txt"}
 
     Enum.reduce(filename_options_map, [], fn {opt_name, filename}, acc ->
       filepath = Path.join(base_dir, filename)

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -79,7 +79,7 @@ defmodule Pinchflat.YtDlp.CommandRunner do
 
     filename_options_map = %{
       cookies: "cookies.txt",
-      config_locations: "yt-dlp-config.txt"
+      config_locations: "yt-dlp-configs/main.txt"
     }
 
     Enum.reduce(filename_options_map, [], fn {opt_name, filename}, acc ->

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -27,13 +27,14 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   def run(url, command_opts, output_template, addl_opts \\ []) do
     # This approach lets us mock the command for testing
     command = backend_executable()
-    # These must stay in exactly this order, hence why I'm giving it its own variable.
-    # Also, can't use RAM file since yt-dlp needs a concrete filepath.
+
     output_filepath = generate_output_filepath(addl_opts)
     print_to_file_opts = [{:print_to_file, output_template}, output_filepath]
-    cookie_opts = build_cookie_options()
-    formatted_command_opts = [url] ++ CliUtils.parse_options(command_opts ++ print_to_file_opts ++ cookie_opts)
+    external_file_opts = build_external_file_options()
+    # These must stay in exactly this order, hence why I'm giving it its own variable.
+    all_opts = command_opts ++ print_to_file_opts ++ external_file_opts
 
+    formatted_command_opts = [url] ++ CliUtils.parse_options(all_opts)
     Logger.info("[yt-dlp] called with: #{Enum.join(formatted_command_opts, " ")}")
 
     case System.cmd(command, formatted_command_opts, stderr_to_stdout: true) do
@@ -73,17 +74,29 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     end
   end
 
-  defp build_cookie_options do
+  defp build_external_file_options do
     base_dir = Application.get_env(:pinchflat, :extras_directory)
-    cookie_file = Path.join(base_dir, "cookies.txt")
 
-    case File.read(cookie_file) do
-      {:ok, cookie_data} ->
-        if String.trim(cookie_data) != "", do: [cookies: cookie_file], else: []
+    filename_options_map = %{
+      cookies: "cookies.txt",
+      config_locations: "yt-dlp-config.txt"
+    }
 
-      {:error, _} ->
-        []
-    end
+    Enum.reduce(filename_options_map, [], fn {opt_name, filename}, acc ->
+      filepath = Path.join(base_dir, filename)
+
+      case File.read(filepath) do
+        {:ok, file_data} ->
+          if String.trim(file_data) != "" do
+            [{opt_name, filepath} | acc]
+          else
+            acc
+          end
+
+        {:error, _} ->
+          acc
+      end
+    end)
   end
 
   defp backend_executable do

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -42,7 +42,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
 
     test "creates a blank yt-dlp config file" do
       base_dir = Application.get_env(:pinchflat, :extras_directory)
-      filepath = Path.join([base_dir, "yt-dlp-configs", "main.txt"])
+      filepath = Path.join([base_dir, "yt-dlp-configs", "base-config.txt"])
       File.rm(filepath)
 
       refute File.exists?(filepath)

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -42,7 +42,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
 
     test "creates a blank yt-dlp config file" do
       base_dir = Application.get_env(:pinchflat, :extras_directory)
-      filepath = Path.join(base_dir, "yt-dlp-config.txt")
+      filepath = Path.join([base_dir, "yt-dlp-configs", "main.txt"])
       File.rm(filepath)
 
       refute File.exists?(filepath)

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -27,10 +27,22 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
     end
   end
 
-  describe "create_blank_cookie_file" do
+  describe "create_blank_yt_dlp_files" do
     test "creates a blank cookie file" do
       base_dir = Application.get_env(:pinchflat, :extras_directory)
       filepath = Path.join(base_dir, "cookies.txt")
+      File.rm(filepath)
+
+      refute File.exists?(filepath)
+
+      PreJobStartupTasks.init(%{})
+
+      assert File.exists?(filepath)
+    end
+
+    test "creates a blank yt-dlp config file" do
+      base_dir = Application.get_env(:pinchflat, :extras_directory)
+      filepath = Path.join(base_dir, "yt-dlp-config.txt")
       File.rm(filepath)
 
       refute File.exists?(filepath)

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -76,32 +76,6 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
       refute String.contains?(output, "--cookies")
       refute String.contains?(output, cookie_file)
     end
-
-    test "includes yt-dlp options when config file exists", %{yt_dlp_file: yt_dlp_file} do
-      FilesystemUtils.write_p!(yt_dlp_file, "config data")
-
-      assert {:ok, output} = Runner.run(@media_url, [], "")
-
-      assert String.contains?(output, "--config-locations #{yt_dlp_file}")
-    end
-
-    test "doesn't include yt-dlp options when config file blank", %{yt_dlp_file: yt_dlp_file} do
-      FilesystemUtils.write_p!(yt_dlp_file, " \n \n ")
-
-      assert {:ok, output} = Runner.run(@media_url, [], "")
-
-      refute String.contains?(output, "--config-locations")
-      refute String.contains?(output, yt_dlp_file)
-    end
-
-    test "ddoesn't include yt-dlp options when config file doesn't exist", %{yt_dlp_file: yt_dlp_file} do
-      File.rm(yt_dlp_file)
-
-      assert {:ok, output} = Runner.run(@media_url, [], "")
-
-      refute String.contains?(output, "--config-locations")
-      refute String.contains?(output, yt_dlp_file)
-    end
   end
 
   describe "version/0" do

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -46,7 +46,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     setup do
       base_dir = Application.get_env(:pinchflat, :extras_directory)
       cookie_file = Path.join(base_dir, "cookies.txt")
-      yt_dlp_file = Path.join(base_dir, "yt-dlp-config.txt")
+      yt_dlp_file = Path.join([base_dir, "yt-dlp-configs", "main.txt"])
 
       {:ok, cookie_file: cookie_file, yt_dlp_file: yt_dlp_file}
     end


### PR DESCRIPTION
## What's new?

- Adds ability to use custom `yt-dlp` options via config files
  - Resolves #174
  - Resolves #175
  - Supports both a base config that applies to all downloads and scoped configs that work on a per-profile/source/media basis 
  - [Docs](https://github.com/kieraneglin/pinchflat/wiki/%5BAdvanced%5D-Custom-yt%E2%80%90dlp-options)

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

