### PR TITLE
[Enhancement] Improve support for 4k videos with Plex

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -106,7 +106,6 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   end
 
   defp quality_options(media_profile) do
-    # TODO: test
     video_codec_option = fn res ->
       [format_sort: "res:#{res},+codec:avc:m4a", remux_video: "mp4"]
     end

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -106,16 +106,19 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   end
 
   defp quality_options(media_profile) do
-    video_codec_options = "+codec:avc:m4a"
+    # TODO: test
+    video_codec_option = fn res ->
+      [format_sort: "res:#{res},+codec:avc:m4a", remux_video: "mp4"]
+    end
 
     case media_profile.preferred_resolution do
       # Also be aware that :audio disabled all embedding options for subtitles
       :audio -> [:extract_audio, format: "bestaudio[ext=m4a]"]
-      :"360p" -> [format_sort: "res:360,#{video_codec_options}"]
-      :"480p" -> [format_sort: "res:480,#{video_codec_options}"]
-      :"720p" -> [format_sort: "res:720,#{video_codec_options}"]
-      :"1080p" -> [format_sort: "res:1080,#{video_codec_options}"]
-      :"2160p" -> [format_sort: "res:2160,#{video_codec_options}"]
+      :"360p" -> video_codec_option.("360")
+      :"480p" -> video_codec_option.("480")
+      :"720p" -> video_codec_option.("720")
+      :"1080p" -> video_codec_option.("1080")
+      :"2160p" -> video_codec_option.("2160")
     end
   end
 

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -240,6 +240,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
 
         assert {:ok, res} = DownloadOptionBuilder.build(media_item)
         assert {:format_sort, "res:#{resolution},+codec:avc:m4a"} in res
+        assert {:remux_video, "mp4"} in res
       end)
     end
 
@@ -250,6 +251,8 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
 
       assert :extract_audio in res
       assert {:format, "bestaudio[ext=m4a]"} in res
+
+      refute {:remux_video, "mp4"} in res
     end
   end
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Resolves an issue where media metadata wasn't being imported by Plex since Plex doesn't support reading tags from `.mkv` files for some reason
  - The fix is to remux to change out the mkv container for an mp4 container. This should be a no-op for all resolutions <= 1080p and only add a small processing time for larger files. Resolves #180

## Any other comments?

N/A

