### PR TITLE
[Enhancement] Improve embedded metadata date compatibility 

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -42,8 +42,14 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   end
 
   defp default_options do
-    # Add force-overwrites to make sure redownloading works
-    [:no_progress, :windows_filenames, :force_overwrites]
+    [
+      :no_progress,
+      :windows_filenames,
+      # Add force-overwrites to make sure redownloading works
+      :force_overwrites,
+      # This makes the date metadata conform to what jellyfin expects
+      parse_metadata: "%(upload_date>%Y-%m-%d)s:(?P<meta_date>.+)"
+    ]
   end
 
   defp subtitle_options(media_profile) do

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -55,6 +55,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert :no_progress in res
       assert :windows_filenames in res
       assert :force_overwrites in res
+      assert {:parse_metadata, "%(upload_date>%Y-%m-%d)s:(?P<meta_date>.+)"} in res
     end
   end
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Changes embedded metadata date to `YYYY-MM-DD` to improve compatibility with Jellyfin (resolves #183)

## What's fixed?

N/A

## Any other comments?

N/A

