### PR TITLE
[Bugfix]: Misc. bugfixes 2024-04-16

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,6 +36,17 @@ let liveSocket = new LiveSocket('/live', Socket, {
         window.Alpine.clone(from, to)
       }
     }
+  },
+  hooks: {
+    supressEnterSubmission: {
+      mounted() {
+        this.el.addEventListener('keypress', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+          }
+        })
+      }
+    }
   }
 })
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -29,6 +29,9 @@ RUN yt-dlp -U
 # Download Apprise
 RUN python3 -m pip install -U apprise --break-system-packages
 
+# Download Mutagen for music thumbnail generation
+RUN python3 -m pip install -U mutagen --break-system-packages
+
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8

--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -54,11 +54,18 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
 
   @doc """
   Downloads and stores a thumbnail for a media item, returning the filepath.
+  Chooses the highest quality jpg thumbnail available.
 
   Returns binary()
   """
   def download_and_store_thumbnail_for(database_record, metadata_map) do
-    thumbnail_url = metadata_map["thumbnail"]
+    thumbnail_url =
+      metadata_map["thumbnails"]
+      |> Enum.filter(&(&1["preference"] && String.ends_with?(&1["url"], ".jpg")))
+      |> Enum.sort(&(&1["preference"] >= &2["preference"]))
+      |> List.first()
+      |> Map.get("url")
+
     filepath = generate_filepath_for(database_record, Path.basename(thumbnail_url))
     thumbnail_blob = fetch_thumbnail_from_url(thumbnail_url)
 

--- a/lib/pinchflat_web/components/layouts/partials/upgrade_button_live.ex
+++ b/lib/pinchflat_web/components/layouts/partials/upgrade_button_live.ex
@@ -3,10 +3,11 @@ defmodule Pinchflat.UpgradeButtonLive do
 
   def render(assigns) do
     ~H"""
-    <form phx-change="check_matching_text">
+    <form id="upgradeForm" phx-change="check_matching_text" phx-hook="supressEnterSubmission">
       <.input type="text" name="unlock-pro-textbox" value="" />
     </form>
 
+    <%!-- The setTimeout is so the modal has time to disappear before it's removed --%>
     <.button
       class="w-full mt-4"
       type="button"

--- a/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_controller.ex
@@ -50,7 +50,13 @@ defmodule PinchflatWeb.MediaItems.MediaItemController do
 
   def force_download(conn, %{"media_item_id" => id}) do
     media_item = Media.get_media_item!(id)
-    {:ok, _} = MediaDownloadWorker.kickoff_with_task(media_item, %{force: true})
+
+    :ok =
+      case MediaDownloadWorker.kickoff_with_task(media_item, %{force: true}) do
+        {:ok, _} -> :ok
+        {:error, :duplicate_job} -> :ok
+        err -> err
+      end
 
     conn
     |> put_flash(:info, "Download task enqueued.")

--- a/selfhosted.Dockerfile
+++ b/selfhosted.Dockerfile
@@ -90,6 +90,9 @@ RUN yt-dlp -U
 # Download Apprise
 RUN python3 -m pip install -U apprise --break-system-packages
 
+# Download Mutagen for music thumbnail generation
+RUN python3 -m pip install -U mutagen --break-system-packages
+
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -731,9 +731,7 @@ defmodule Pinchflat.MediaTest do
         metadata: %{
           metadata_filepath: MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{}),
           thumbnail_filepath:
-            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, %{
-              "thumbnail" => "https://example.com/thumbnail.jpg"
-            })
+            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, render_parsed_metadata(:media_metadata))
         }
       }
 
@@ -760,9 +758,7 @@ defmodule Pinchflat.MediaTest do
         metadata: %{
           metadata_filepath: MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{}),
           thumbnail_filepath:
-            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, %{
-              "thumbnail" => "https://example.com/thumbnail.jpg"
-            })
+            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, render_parsed_metadata(:media_metadata))
         }
       }
 
@@ -831,9 +827,7 @@ defmodule Pinchflat.MediaTest do
         metadata: %{
           metadata_filepath: MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{}),
           thumbnail_filepath:
-            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, %{
-              "thumbnail" => "https://example.com/thumbnail.jpg"
-            })
+            MetadataFileHelpers.download_and_store_thumbnail_for(media_item, render_parsed_metadata(:media_metadata))
         }
       }
 

--- a/test/pinchflat_web/controllers/media_item_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_item_controller_test.exs
@@ -97,6 +97,15 @@ defmodule PinchflatWeb.MediaItemControllerTest do
       assert [_] = all_enqueued(worker: MediaDownloadWorker)
     end
 
+    test "doesn't freak out if the task is a duplicate", %{conn: conn} do
+      media_item = media_item_fixture()
+
+      MediaDownloadWorker.kickoff_with_task(media_item, %{force: true})
+
+      post(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item.id}/force_download")
+      assert [_] = all_enqueued(worker: MediaDownloadWorker)
+    end
+
     test "forces a download even if one wouldn't normally run", %{conn: conn} do
       media_item = media_item_fixture(%{media_filepath: nil})
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Manually installs mutagen since that was lost when I switched from python installation to binary installation
- Update media item metadata fetcher to pull the highest quality JPG

## What's fixed?

- Stopped "pro" upgrade form from submitting on enter (causing a page reload)
- Improved UX for forcing a download of a media item that already has a DL enqueued

## Any other comments?

N/A

