### PR TITLE
[Enhancement] Allow forcing a refresh of source metadata

### DIFF
--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -38,9 +38,9 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     - The NFO file for the source (if specified)
     - Downloads and stores source images (if specified)
 
-  The worker is kicked off after a source is inserted/updated - this can
-  take an unknown amount of time so don't rely on this data being here
-  before, say, the first indexing or downloading task is complete.
+  The worker is kicked off after a source is inserted or it's original_url
+  is updated - this can take an unknown amount of time so don't rely on this
+  data being here before, say, the first indexing or downloading task is complete.
 
   Returns :ok
   """

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -36,6 +36,15 @@ defmodule PinchflatWeb.Sources.SourceHTML do
     |> Phoenix.json_library().encode!()
   end
 
+  def title_filter_regex_help do
+    url = "https://github.com/nalgeon/sqlean/blob/main/docs/regexp.md#supported-syntax"
+    classes = "underline decoration-bodydark decoration-1 hover:decoration-white"
+
+    """
+    A PCRE-compatible regex. Only media with titles that match this regex will be downloaded. <a href="#{url}" class="#{classes}" target="_blank">See here</a> for syntax
+    """
+  end
+
   def output_path_template_override_help do
     help_button_classes = "underline decoration-bodydark decoration-1 hover:decoration-white cursor-pointer"
     help_button = ~s{<span class="#{help_button_classes}" x-on:click="$dispatch('load-template')">Click here</span>}

--- a/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
@@ -31,6 +31,15 @@
     </.link>
   </:option>
   <:option>
+    <.link
+      href={~p"/sources/#{@source}/force_metadata_refresh"}
+      method="post"
+      data-confirm="Are you sure you want to refresh this source's metadata?"
+    >
+      Refresh Metadata
+    </.link>
+  </:option>
+  <:option>
     <div class="h-px w-full bg-bodydark2"></div>
   </:option>
   <:option>

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -23,7 +23,7 @@
       field={f[:custom_name]}
       type="text"
       label="Custom Name"
-      help="Something descriptive. Does not impact indexing or downloading"
+      help="Does not impact indexing or downloading. Will be inferred from the source if left blank"
     />
 
     <.input field={f[:original_url]} type="text" label="Source URL" help="URL of a channel or playlist (required)" />
@@ -111,7 +111,8 @@
         type="text"
         label="Title Filter Regex"
         placeholder="(?i)^How to Bike$"
-        help="A PCRE-compatible regex. Only media with titles that match this regex will be downloaded. Look up 'SQLean Regex docs' for more"
+        help={title_filter_regex_help()}
+        html_help={true}
       />
 
       <section

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -35,6 +35,7 @@ defmodule PinchflatWeb.Router do
     resources "/sources", Sources.SourceController do
       post "/force_download", Sources.SourceController, :force_download
       post "/force_index", Sources.SourceController, :force_index
+      post "/force_metadata_refresh", Sources.SourceController, :force_metadata_refresh
 
       resources "/media", MediaItems.MediaItemController, only: [:show, :edit, :update, :delete] do
         post "/force_download", MediaItems.MediaItemController, :force_download

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -9,6 +9,7 @@ defmodule PinchflatWeb.SourceControllerTest do
   alias Pinchflat.Repo
   alias Pinchflat.Settings
   alias Pinchflat.Downloading.MediaDownloadWorker
+  alias Pinchflat.Metadata.SourceMetadataStorageWorker
   alias Pinchflat.SlowIndexing.MediaCollectionIndexingWorker
 
   setup do
@@ -211,6 +212,23 @@ defmodule PinchflatWeb.SourceControllerTest do
       source = source_fixture()
 
       conn = post(conn, ~p"/sources/#{source.id}/force_index")
+      assert redirected_to(conn) == ~p"/sources/#{source.id}"
+    end
+  end
+
+  describe "force_metadata_refresh" do
+    test "forces a metadata refresh", %{conn: conn} do
+      source = source_fixture()
+
+      assert [] = all_enqueued(worker: SourceMetadataStorageWorker)
+      post(conn, ~p"/sources/#{source.id}/force_metadata_refresh")
+      assert [_] = all_enqueued(worker: SourceMetadataStorageWorker)
+    end
+
+    test "redirects to the source page", %{conn: conn} do
+      source = source_fixture()
+
+      conn = post(conn, ~p"/sources/#{source.id}/force_metadata_refresh")
       assert redirected_to(conn) == ~p"/sources/#{source.id}"
     end
   end


### PR DESCRIPTION
## What's new?

- Adds ability to force the refresh of a source's metadata from the actions menu

## What's changed?

- Sources now only refresh their metadata (including images) when the `original_url` is changed instead of on _any_ change (resolves #185)

## What's fixed?

N/A

## Any other comments?

N/A

