### PR TITLE
[Enhancement] Optionally add episode art to podcast feeds

### DIFF
--- a/lib/pinchflat/podcasts/rss_feed_builder.ex
+++ b/lib/pinchflat/podcasts/rss_feed_builder.ex
@@ -75,6 +75,8 @@ defmodule Pinchflat.Podcasts.RssFeedBuilder do
   end
 
   defp build_media_item_xml(source, media_item, url_base) do
+    item_image_path = item_image_path(url_base, media_item)
+
     """
     <item>
       <guid isPermaLink="false">#{media_item.uuid}</guid>
@@ -91,6 +93,10 @@ defmodule Pinchflat.Podcasts.RssFeedBuilder do
       <itunes:author>#{safe(source.custom_name)}</itunes:author>
       <itunes:subtitle>#{safe(media_item.title)}</itunes:subtitle>
       <itunes:summary><![CDATA[#{media_item.description}]]></itunes:summary>
+
+      #{item_image_path && ~s(<itunes:image href="#{safe(item_image_path)}"></itunes:image>)}
+      #{item_image_path && ~s(<podcast:images srcset="#{safe(item_image_path)}" />)}
+
       <itunes:explicit>false</itunes:explicit>
     </item>
     """
@@ -114,6 +120,16 @@ defmodule Pinchflat.Podcasts.RssFeedBuilder do
       {:ok, filepath} ->
         extension = Path.extname(filepath)
         Path.join(url_base, "#{podcast_route(:feed_image, source.uuid)}#{extension}")
+    end
+  end
+
+  def item_image_path(url_base, media_item) do
+    if media_item.thumbnail_filepath && File.exists?(media_item.thumbnail_filepath) do
+      extension = Path.extname(media_item.thumbnail_filepath)
+
+      Path.join(url_base, "#{podcast_route(:episode_image, media_item.uuid)}#{extension}")
+    else
+      nil
     end
   end
 

--- a/lib/pinchflat_web/controllers/podcasts/podcast_controller.ex
+++ b/lib/pinchflat_web/controllers/podcasts/podcast_controller.ex
@@ -2,8 +2,9 @@ defmodule PinchflatWeb.Podcasts.PodcastController do
   use PinchflatWeb, :controller
 
   alias Pinchflat.Repo
-  alias Pinchflat.Media.MediaQuery
   alias Pinchflat.Sources.Source
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Media.MediaQuery
   alias Pinchflat.Podcasts.RssFeedBuilder
   alias Pinchflat.Podcasts.PodcastHelpers
 
@@ -38,6 +39,18 @@ defmodule PinchflatWeb.Podcasts.PodcastController do
         conn
         |> put_resp_content_type(MIME.from_path(filepath))
         |> send_file(200, filepath)
+    end
+  end
+
+  def episode_image(conn, %{"uuid" => uuid}) do
+    media_item = Repo.get_by!(MediaItem, uuid: uuid)
+
+    if media_item.thumbnail_filepath && File.exists?(media_item.thumbnail_filepath) do
+      conn
+      |> put_resp_content_type(MIME.from_path(media_item.thumbnail_filepath))
+      |> send_file(200, media_item.thumbnail_filepath)
+    else
+      send_resp(conn, 404, "Image not found")
     end
   end
 end

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -50,6 +50,7 @@ defmodule PinchflatWeb.Router do
 
     get "/sources/:uuid/feed", Podcasts.PodcastController, :rss_feed
     get "/sources/:uuid/feed_image", Podcasts.PodcastController, :feed_image
+    get "/media/:uuid/episode_image", Podcasts.PodcastController, :episode_image
 
     get "/media/:uuid/stream", MediaItems.MediaItemController, :stream
   end

--- a/test/pinchflat_web/controllers/podcast_controller_test.exs
+++ b/test/pinchflat_web/controllers/podcast_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule PinchflatWeb.PodcastControllerTest do
   use PinchflatWeb.ConnCase
 
+  import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
 
   describe "rss_feed" do
@@ -30,6 +31,27 @@ defmodule PinchflatWeb.PodcastControllerTest do
       source = source_fixture()
 
       conn = get(conn, ~p"/sources/#{source.uuid}/feed_image" <> ".jpg")
+
+      assert conn.status == 404
+      assert conn.resp_body == "Image not found"
+    end
+  end
+
+  describe "episode_image" do
+    test "returns an episode image if one can be found", %{conn: conn} do
+      media_item = media_item_with_attachments()
+
+      conn = get(conn, ~p"/media/#{media_item.uuid}/episode_image" <> ".jpg")
+
+      assert conn.status == 200
+      assert {"content-type", "image/jpeg; charset=utf-8"} in conn.resp_headers
+      assert conn.resp_body == File.read!(media_item.thumbnail_filepath)
+    end
+
+    test "returns 404 if an image cannot be found", %{conn: conn} do
+      media_item = media_item_fixture()
+
+      conn = get(conn, ~p"/media/#{media_item.uuid}/episode_image" <> ".jpg")
 
       assert conn.status == 404
       assert conn.resp_body == "Image not found"

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -67,16 +67,24 @@ defmodule Pinchflat.MediaFixtures do
   end
 
   def media_item_with_attachments(attrs \\ %{}) do
-    stored_media_filepath =
+    base_dir =
       Path.join([
         Application.get_env(:pinchflat, :media_directory),
-        "#{:rand.uniform(1_000_000)}",
-        "#{:rand.uniform(1_000_000)}_media.mp4"
+        "#{:rand.uniform(1_000_000)}"
       ])
 
-    FilesystemUtils.cp_p!(media_filepath_fixture(), stored_media_filepath)
+    stored_media_filepath = Path.join(base_dir, "#media.mp4")
+    thumbnail_filepath = Path.join(base_dir, "thumbnail.jpg")
 
-    merged_attrs = Map.merge(attrs, %{media_filepath: stored_media_filepath})
+    FilesystemUtils.cp_p!(media_filepath_fixture(), stored_media_filepath)
+    FilesystemUtils.cp_p!(thumbnail_filepath_fixture(), thumbnail_filepath)
+
+    merged_attrs =
+      Map.merge(attrs, %{
+        media_filepath: stored_media_filepath,
+        thumbnail_filepath: thumbnail_filepath
+      })
+
     media_item_fixture(merged_attrs)
   end
 


### PR DESCRIPTION
## What's new?

- Adds endpoints and XML for including episode images in podcast feeds (resolves #200)
  - Some people (like me) prefer to use channel-level images in all cases. To support that, this feature uses the media thumbnails as the episode artwork. Don't want episode art? Don't download thumbnails 🤙 

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

