### PR TITLE
[Bugfix] Stop Apprise notifications from being sent if the Source doesn't download media

### DIFF
--- a/lib/pinchflat/notifications/source_notifications.ex
+++ b/lib/pinchflat/notifications/source_notifications.ex
@@ -53,7 +53,11 @@ defmodule Pinchflat.Notifications.SourceNotifications do
   end
 
   defp relevant_media_item_count(source) do
-    pending_media_item_count(source) + downloaded_media_item_count(source)
+    if source.download_media do
+      pending_media_item_count(source) + downloaded_media_item_count(source)
+    else
+      0
+    end
   end
 
   defp pending_media_item_count(source) do

--- a/test/pinchflat/notifications/source_notifications_test.exs
+++ b/test/pinchflat/notifications/source_notifications_test.exs
@@ -60,6 +60,17 @@ defmodule Pinchflat.Notifications.SourceNotificationsTest do
       end)
     end
 
+    test "does not send a notification if the source is set to not download media" do
+      source = source_fixture(%{download_media: false})
+
+      expect(AppriseRunnerMock, :run, 0, fn _, _ -> {:ok, ""} end)
+
+      SourceNotifications.wrap_new_media_notification(@apprise_servers, source, fn ->
+        media_item_fixture(%{source_id: source.id, media_filepath: nil})
+        media_item_fixture(%{source_id: source.id, media_filepath: "file.mp4"})
+      end)
+    end
+
     test "returns the value of the function" do
       source = source_fixture()
       expect(AppriseRunnerMock, :run, 0, fn _, _ -> {:ok, ""} end)


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Stops Apprise notifications from being sent if the Source doesn't download media (resolves #215)

## Any other comments?

N/A


