### PR TITLE
[Housekeeping] Improved robustness of metadata parsing

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -124,9 +124,18 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
       [format_sort: "res:#{res},+codec:avc:m4a", remux_video: "mp4"]
     end
 
+    audio_format_precedence = [
+      "bestaudio[ext=m4a]",
+      "bestaudio[ext=mp3]",
+      "bestaudio",
+      "best[ext=m4a]",
+      "best[ext=mp3]",
+      "best"
+    ]
+
     case media_profile.preferred_resolution do
       # Also be aware that :audio disabled all embedding options for subtitles
-      :audio -> [:extract_audio, format: "bestaudio[ext=m4a]"]
+      :audio -> [:extract_audio, format: Enum.join(audio_format_precedence, "/")]
       :"360p" -> video_codec_option.("360")
       :"480p" -> video_codec_option.("480")
       :"720p" -> video_codec_option.("720")

--- a/lib/pinchflat/metadata/metadata_parser.ex
+++ b/lib/pinchflat/metadata/metadata_parser.ex
@@ -30,7 +30,7 @@ defmodule Pinchflat.Metadata.MetadataParser do
       original_url: metadata["original_url"],
       description: metadata["description"],
       media_filepath: metadata["filepath"],
-      livestream: metadata["was_live"],
+      livestream: !!metadata["was_live"],
       duration_seconds: metadata["duration"] && round(metadata["duration"])
     }
   end

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -87,7 +87,7 @@ defmodule Pinchflat.YtDlp.Media do
       title: response["title"],
       description: response["description"],
       original_url: response["webpage_url"],
-      livestream: response["was_live"],
+      livestream: !!response["was_live"],
       duration_seconds: response["duration"] && round(response["duration"]),
       short_form_content: response["webpage_url"] && short_form_content?(response),
       upload_date: response["upload_date"] && MetadataFileHelpers.parse_upload_date(response["upload_date"])

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
@@ -32,7 +32,7 @@
               </div>
               <aside class="mt-4 xl:mt-0">
                 <div>Uploaded: <%= @media_item.upload_date %></div>
-                <div>
+                <div :if={URI.parse(@media_item.original_url).scheme =~ "http"}>
                   <.subtle_link href={@media_item.original_url} target="_blank">Open Original</.subtle_link>
                 </div>
                 <div class="mt-4 text-bodydark">

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -259,7 +259,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
       assert :extract_audio in res
-      assert {:format, "bestaudio[ext=m4a]"} in res
+      assert {:format, "bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio/best[ext=m4a]/best[ext=mp3]/best"} in res
 
       refute {:remux_video, "mp4"} in res
     end

--- a/test/pinchflat/metadata/metadata_file_helpers_test.exs
+++ b/test/pinchflat/metadata/metadata_file_helpers_test.exs
@@ -89,6 +89,48 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
 
       assert filepath =~ ~r{/media_items/#{media_item.id}/img_2.jpg}
     end
+
+    test "will fall back to a non-jpg if it has to", %{media_item: media_item} do
+      metadata = %{
+        "thumbnails" => [
+          %{"url" => "https://i.ytimg.com/vi/ABC123/img_1.webp", "preference" => -1}
+        ]
+      }
+
+      filepath = Helpers.download_and_store_thumbnail_for(media_item, metadata)
+
+      assert filepath =~ ~r{/media_items/#{media_item.id}/img_1.webp}
+    end
+
+    test "does not require a preference field", %{media_item: media_item} do
+      metadata = %{
+        "thumbnails" => [
+          %{"url" => "https://i.ytimg.com/vi/ABC123/img_1.webp"}
+        ]
+      }
+
+      filepath = Helpers.download_and_store_thumbnail_for(media_item, metadata)
+
+      assert filepath =~ ~r{/media_items/#{media_item.id}/img_1.webp}
+    end
+  end
+
+  describe "download_and_store_thumbnail_for/2 when not downloading thumbnails" do
+    test "returns nil if there are no thumbnails", %{media_item: media_item} do
+      metadata = %{"thumbnails" => []}
+
+      filepath = Helpers.download_and_store_thumbnail_for(media_item, metadata)
+
+      assert filepath == nil
+    end
+
+    test "returns nil if there is no thumbnail field", %{media_item: media_item} do
+      metadata = %{}
+
+      filepath = Helpers.download_and_store_thumbnail_for(media_item, metadata)
+
+      assert filepath == nil
+    end
   end
 
   describe "parse_upload_date/1" do

--- a/test/pinchflat/metadata/metadata_parser_test.exs
+++ b/test/pinchflat/metadata/metadata_parser_test.exs
@@ -46,6 +46,14 @@ defmodule Pinchflat.Metadata.MetadataParserTest do
       assert result.livestream == metadata["was_live"]
     end
 
+    test "the livestream flag defaults to false", %{metadata: metadata} do
+      metadata = Map.put(metadata, "was_live", nil)
+
+      result = Parser.parse_for_media_item(metadata)
+
+      assert result.livestream == false
+    end
+
     test "it extracts the duration in seconds", %{metadata: metadata} do
       result = Parser.parse_for_media_item(metadata)
 

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -199,5 +199,16 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
       assert %Media{duration_seconds: nil} = Media.response_to_struct(response)
     end
+
+    test "sets livestream to false if the was_live field isn't present" do
+      response = %{
+        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "aspect_ratio" => 1.0,
+        "duration" => 60,
+        "upload_date" => "20210101"
+      }
+
+      assert %Media{livestream: false} = Media.response_to_struct(response)
+    end
   end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Audio-only sources now have a proper precedence set if an m4a cannot be found
- `livestream` is set to false if not present in the attributes payload
- Thumbnail downloads now work if they aren't returned with a `preference` field
- Thumbnails will now allow non-jpg images to download, but jpg is has a significantly higher priority
- `Open Original` in the Media Item show page is no longer present if the `original_url` field doesn't contain a valid URI

## What's fixed?

N/A

## Any other comments?

N/A

