### PR TITLE
[Enhancement] Made timezone data location user-configurable

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,8 +7,6 @@ import Config
 # before starting your production server.
 config :pinchflat, PinchflatWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
 
-config :tzdata, :data_dir, "/etc/elixir_tzdata_data"
-
 # Configures Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: Pinchflat.Finch
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,8 @@ if config_env() == :prod do
     expose_feed_endpoints: expose_feed_endpoints,
     timezone: System.get_env("TIMEZONE") || System.get_env("TZ") || "UTC"
 
+  config :tzdata, :data_dir, System.get_env("TZ_DATA_DIR", "/etc/elixir_tzdata_data")
+
   config :pinchflat, Pinchflat.Repo,
     database: db_path,
     journal_mode: journal_mode

--- a/lib/pinchflat/release.ex
+++ b/lib/pinchflat/release.ex
@@ -26,14 +26,17 @@ defmodule Pinchflat.Release do
     load_app()
 
     directories =
-      Enum.uniq([
+      [
         "/config",
         "/downloads",
         Application.get_env(:pinchflat, :media_directory),
         Application.get_env(:pinchflat, :tmpfile_directory),
         Application.get_env(:pinchflat, :extras_directory),
-        Application.get_env(:pinchflat, :metadata_directory)
-      ])
+        Application.get_env(:pinchflat, :metadata_directory),
+        Application.get_env(:tzdata, :data_dir)
+      ]
+      |> Enum.uniq()
+      |> Enum.filter(&(&1 != nil))
 
     Enum.each(directories, fn dir ->
       Logger.info("Checking permissions for #{dir}")


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Allows specifying where to store Elixir's internal timezone database via `TZ_DATA_DIR`
  - Can be helpful when working with read-only filesystems (resolves #237)

## What's fixed?

N/A

## Any other comments?

N/A


