### PR TITLE
[Bugfix] Order RSS feed by upload date

### DIFF
--- a/lib/pinchflat/podcasts/podcast_helpers.ex
+++ b/lib/pinchflat/podcasts/podcast_helpers.ex
@@ -24,11 +24,12 @@ defmodule Pinchflat.Podcasts.PodcastHelpers do
   Returns: [%MediaItem{}]
   """
   def persisted_media_items_for(source, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 500)
+    limit = Keyword.get(opts, :limit, 1_000)
 
     MediaQuery.new()
     |> MediaQuery.for_source(source)
     |> MediaQuery.with_media_filepath()
+    |> order_by(desc: :upload_date)
     |> Repo.maybe_limit(limit)
     |> Repo.all()
     |> Enum.filter(fn media_item -> File.exists?(media_item.media_filepath) end)

--- a/lib/pinchflat/podcasts/rss_feed_builder.ex
+++ b/lib/pinchflat/podcasts/rss_feed_builder.ex
@@ -16,12 +16,12 @@ defmodule Pinchflat.Podcasts.RssFeedBuilder do
   Only MediaItems that have been persisted will be included in the feed.
 
   ## Options:
-    - `:limit` - The maximum number of media items to include in the feed. Defaults to 300.
+    - `:limit` - The maximum number of media items to include in the feed. Defaults to 2,000.
 
   Returns an XML document as a string.
   """
   def build(source, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 300)
+    limit = Keyword.get(opts, :limit, 2_000)
     url_base = Keyword.get(opts, :url_base, PinchflatWeb.Endpoint.url())
 
     media_items = PodcastHelpers.persisted_media_items_for(source, limit: limit)

--- a/lib/pinchflat_web/controllers/podcasts/podcast_controller.ex
+++ b/lib/pinchflat_web/controllers/podcasts/podcast_controller.ex
@@ -11,7 +11,7 @@ defmodule PinchflatWeb.Podcasts.PodcastController do
   def rss_feed(conn, %{"uuid" => uuid}) do
     source = Repo.get_by!(Source, uuid: uuid)
     url_base = url(conn, ~p"/")
-    xml = RssFeedBuilder.build(source, limit: 300, url_base: url_base)
+    xml = RssFeedBuilder.build(source, limit: 2_000, url_base: url_base)
 
     conn
     |> put_resp_content_type("application/rss+xml")

--- a/priv/repo/migrations/20240515163649_add_date_indexes_to_media_items.exs
+++ b/priv/repo/migrations/20240515163649_add_date_indexes_to_media_items.exs
@@ -1,0 +1,8 @@
+defmodule Pinchflat.Repo.Migrations.AddDateIndexesToMediaItems do
+  use Ecto.Migration
+
+  def change do
+    create(index(:media_items, [:media_downloaded_at]))
+    create(index(:media_items, [:media_redownloaded_at]))
+  end
+end

--- a/test/pinchflat/podcasts/podcast_helpers_test.exs
+++ b/test/pinchflat/podcasts/podcast_helpers_test.exs
@@ -22,6 +22,16 @@ defmodule Pinchflat.Podcasts.PodcastHelpersTest do
 
       assert [] = PodcastHelpers.persisted_media_items_for(source, limit: 0)
     end
+
+    test "orders by upload date where newest is first" do
+      source = source_fixture()
+
+      oldest = media_item_with_attachments(%{source_id: source.id, upload_date: now_minus(2, :day)})
+      current = media_item_with_attachments(%{source_id: source.id, upload_date: now()})
+      older = media_item_with_attachments(%{source_id: source.id, upload_date: now_minus(1, :days)})
+
+      assert [^current, ^older, ^oldest] = PodcastHelpers.persisted_media_items_for(source)
+    end
   end
 
   describe "select_cover_image/2" do


### PR DESCRIPTION
## What's new?

- Adds index for a media item's download and redownload dates

## What's changed?

- Increases limit on RSS feed from 300 to 2,000 (resolves #240)

## What's fixed?

- Orders RSS feed by upload date with the newest items being on top (resolves #240)

## Any other comments?

N/A

