### PR TITLE
[Housekeeping] Improved logging for all executable calls

### DIFF
--- a/lib/pinchflat/lifecycle/notifications/command_runner.ex
+++ b/lib/pinchflat/lifecycle/notifications/command_runner.ex
@@ -29,7 +29,6 @@ defmodule Pinchflat.Lifecycle.Notifications.CommandRunner do
     parsed_opts = CliUtils.parse_options(default_opts ++ command_opts)
 
     {output, exit_code} = CliUtils.wrap_cmd(backend_executable(), parsed_opts ++ endpoints)
-    Logger.info("[apprise] response: #{output}")
 
     case exit_code do
       0 -> {:ok, String.trim(output)}

--- a/lib/pinchflat/lifecycle/user_scripts/command_runner.ex
+++ b/lib/pinchflat/lifecycle/user_scripts/command_runner.ex
@@ -39,7 +39,7 @@ defmodule Pinchflat.Lifecycle.UserScripts.CommandRunner do
       {:ok, executable_path} ->
         {:ok, encoded_data} = Phoenix.json_library().encode(encodable_data)
 
-        {output, exit_code} =
+        {_output, _exit_code} =
           CliUtils.wrap_cmd(
             executable_path,
             [to_string(event_type), encoded_data],
@@ -47,18 +47,12 @@ defmodule Pinchflat.Lifecycle.UserScripts.CommandRunner do
             logging_arg_override: "[suppressed]"
           )
 
-        handle_output(output, exit_code)
+        :ok
     end
   end
 
   def run(event_type, _encodable_data) do
     raise ArgumentError, "Invalid event type: #{inspect(event_type)}"
-  end
-
-  defp handle_output(output, exit_code) do
-    Logger.debug("Custom lifecycle script exit code: #{exit_code} with output: #{output}")
-
-    :ok
   end
 
   defp backend_executable do

--- a/lib/pinchflat/utils/cli_utils.ex
+++ b/lib/pinchflat/utils/cli_utils.ex
@@ -28,17 +28,10 @@ defmodule Pinchflat.Utils.CliUtils do
 
     Logger.info("[command_wrapper]: #{command} called with: #{logging_arg_override}")
 
-    case System.cmd(wrapper_command, actual_command, passthrough_opts) do
-      {output, 0 = status} ->
-        Logger.debug("[command_wrapper]: #{command} called with: #{logging_arg_override} returned: #{status}")
+    {output, status} = System.cmd(wrapper_command, actual_command, passthrough_opts)
+    log_cmd_result(command, logging_arg_override, status, output)
 
-        {output, status}
-
-      {output, status} ->
-        Logger.error("[command_wrapper]: #{command} called with: #{logging_arg_override} returned: #{status}")
-
-        {output, status}
-    end
+    {output, status}
   end
 
   @doc """
@@ -80,5 +73,12 @@ defmodule Pinchflat.Utils.CliUtils do
 
   defp parse_option(arg, acc) when is_binary(arg) do
     acc ++ [arg]
+  end
+
+  defp log_cmd_result(command, logging_arg_override, status, output) do
+    log_message = "[command_wrapper]: #{command} called with: #{logging_arg_override} exited: #{status} with: #{output}"
+    log_level = if status == 0, do: :debug, else: :error
+
+    Logger.log(log_level, log_message)
   end
 end

--- a/lib/pinchflat/utils/cli_utils.ex
+++ b/lib/pinchflat/utils/cli_utils.ex
@@ -28,7 +28,17 @@ defmodule Pinchflat.Utils.CliUtils do
 
     Logger.info("[command_wrapper]: #{command} called with: #{logging_arg_override}")
 
-    System.cmd(wrapper_command, actual_command, passthrough_opts)
+    case System.cmd(wrapper_command, actual_command, passthrough_opts) do
+      {output, 0 = status} ->
+        Logger.debug("[command_wrapper]: #{command} called with: #{logging_arg_override} returned: #{status}")
+
+        {output, status}
+
+      {output, status} ->
+        Logger.error("[command_wrapper]: #{command} called with: #{logging_arg_override} returned: #{status}")
+
+        {output, status}
+    end
   end
 
   @doc """

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -28,9 +28,9 @@ defmodule Pinchflat.YtDlp.CommandRunner do
 
     output_filepath = generate_output_filepath(addl_opts)
     print_to_file_opts = [{:print_to_file, output_template}, output_filepath]
-    user_configured_opts = cookie_file_options() ++ global_options()
+    user_configured_opts = cookie_file_options()
     # These must stay in exactly this order, hence why I'm giving it its own variable.
-    all_opts = command_opts ++ print_to_file_opts ++ user_configured_opts
+    all_opts = command_opts ++ print_to_file_opts ++ user_configured_opts ++ global_options()
     formatted_command_opts = [url] ++ CliUtils.parse_options(all_opts)
 
     case CliUtils.wrap_cmd(command, formatted_command_opts, stderr_to_stdout: true) do
@@ -71,7 +71,7 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   end
 
   defp global_options do
-    [:windows_filenames]
+    [:windows_filenames, :quiet]
   end
 
   defp cookie_file_options do

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -24,7 +24,7 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     # `ignore_no_formats_error` is necessary because yt-dlp will error out if
     # the first video has not released yet (ie: is a premier). We don't care about
     # available formats since we're just getting the media details
-    command_opts = [:simulate, :skip_download, :ignore_no_formats_error]
+    command_opts = [:simulate, :skip_download, :ignore_no_formats_error, :no_warnings]
     output_template = YtDlpMedia.indexing_output_template()
     output_filepath = FilesystemUtils.generate_metadata_tmpfile(:json)
     file_listener_handler = Keyword.get(addl_opts, :file_listener_handler, false)

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -87,6 +87,12 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
 
       assert String.contains?(output, "--windows-filenames")
     end
+
+    test "runs quietly" do
+      assert {:ok, output} = Runner.run(@media_url, [], "")
+
+      assert String.contains?(output, "--quiet")
+    end
   end
 
   describe "version/0" do

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -20,7 +20,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
     test "it passes the expected default args" do
       expect(YtDlpRunnerMock, :run, fn _url, opts, ot, _addl_opts ->
-        assert opts == [:simulate, :skip_download, :ignore_no_formats_error]
+        assert opts == [:simulate, :skip_download, :ignore_no_formats_error, :no_warnings]
         assert ot == Media.indexing_output_template()
 
         {:ok, ""}


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Updates `CliUtils` to always log the result of a call to an executable (related to #236)

## What's fixed?

N/A

## Any other comments?

N/A

