### PR TITLE
[Bugfix] Fix yt-dlp illegal write issue that causes failure to fetch source details

### DIFF
--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -31,12 +31,21 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   """
   @impl true
   def init(state) do
+    ensure_tmpfile_directory()
     reset_executing_jobs()
     create_blank_yt_dlp_files()
     create_blank_user_script_file()
     apply_default_settings()
 
     {:ok, state}
+  end
+
+  defp ensure_tmpfile_directory do
+    tmpfile_dir = Application.get_env(:pinchflat, :tmpfile_directory)
+
+    if !File.exists?(tmpfile_dir) do
+      File.mkdir_p!(tmpfile_dir)
+    end
   end
 
   # If a node cannot gracefully shut down, the currently executing jobs get stuck

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -13,6 +13,19 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
     :ok
   end
 
+  describe "ensure_tmpfile_directory" do
+    test "creates the tmpfile directory if it doesn't exist" do
+      tmpfile_dir = Application.get_env(:pinchflat, :tmpfile_directory)
+      File.rm_rf!(tmpfile_dir)
+
+      refute File.exists?(tmpfile_dir)
+
+      PreJobStartupTasks.init(%{})
+
+      assert File.exists?(tmpfile_dir)
+    end
+  end
+
   describe "reset_executing_jobs" do
     test "resets executing jobs" do
       job = job_fixture()
@@ -78,6 +91,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
 
   describe "apply_default_settings" do
     test "sets yt_dlp version" do
+      File.rm_rf!(Application.get_env(:pinchflat, :tmpfile_directory))
       Settings.set(yt_dlp_version: nil)
 
       refute Settings.get!(:yt_dlp_version)
@@ -88,6 +102,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
     end
 
     test "sets apprise version" do
+      File.rm_rf!(Application.get_env(:pinchflat, :tmpfile_directory))
       Settings.set(apprise_version: nil)
 
       refute Settings.get!(:apprise_version)

--- a/test/pinchflat/utils/cli_utils_test.exs
+++ b/test/pinchflat/utils/cli_utils_test.exs
@@ -7,6 +7,10 @@ defmodule Pinchflat.Utils.CliUtilsTest do
     test "delegates to System.cmd/3" do
       assert {"output\n", 0} = CliUtils.wrap_cmd("echo", ["output"])
     end
+
+    test "sets the current directory to the tmp dir" do
+      assert {"/tmp/test/tmpfiles\n", 0} = CliUtils.wrap_cmd("pwd", [])
+    end
   end
 
   describe "parse_options/1" do


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

yt-dlp causes an error when it tries to write to a read-only directory. It'll attempt this illegal write if it scans a video that is < ~48 hours old (ie: its only available format is a m3u8 [#616]) AND windows filename compatibility is enabled. The underlying reason isn't fully known. 

This fix gets around this by executing the command from the tmp directory, ensuring it has write access. Related to #236 

## Any other comments?

N/A


