### PR TITLE
[Enhancement] Allow setting preference for video/audio codec

### DIFF
--- a/lib/pinchflat/downloading/codec_parser.ex
+++ b/lib/pinchflat/downloading/codec_parser.ex
@@ -1,5 +1,35 @@
 defmodule Pinchflat.Downloading.CodecParser do
-  # TODO: test
+  @moduledoc """
+  Functions for generating yt-dlp codec strings
+  """
+
+  alias Pinchflat.Settings
+
+  @doc """
+  Generate a video codec string based on the value of the video_codec_preference setting.
+
+  Returns binary()
+  """
+  def generate_vcodec_string_from_settings do
+    generate_vcodec_string(Settings.get!(:video_codec_preference))
+  end
+
+  @doc """
+  Generate an audio codec string based on the value of the audio_codec_preference setting.
+
+  Returns binary()
+  """
+  def generate_acodec_string_from_settings do
+    generate_acodec_string(Settings.get!(:audio_codec_preference))
+  end
+
+  @doc """
+  Generate a video codec string from a list of video codecs.
+
+  If the list is nil or empty, the default video codec is AVC.
+
+  Returns binary()
+  """
   def generate_vcodec_string(nil), do: "bestvideo[vcodec~='^avc']/bestvideo"
   def generate_vcodec_string([]), do: generate_vcodec_string(nil)
 
@@ -8,12 +38,18 @@ defmodule Pinchflat.Downloading.CodecParser do
     |> Enum.map(&video_codec_map()[&1])
     |> Enum.reject(&is_nil/1)
     |> Enum.map(&"bestvideo[vcodec~='^#{&1}']")
-    |> Enum.concat(["bestvideo", "best"])
+    |> Enum.concat(["bestvideo"])
     |> Enum.join("/")
   end
 
-  # TODO: test
-  def generate_acodec_string(nil), do: "bestaudio[acodec~='^mp4a']/bestaudio[acodec~='^mp3']/bestaudio"
+  @doc """
+  Generate an audio codec string from a list of audio codecs.
+
+  If the list is nil or empty, the default audio codec is MP4A.
+
+  Returns binary()
+  """
+  def generate_acodec_string(nil), do: "bestaudio[acodec~='^mp4a']/bestaudio"
   def generate_acodec_string([]), do: generate_acodec_string(nil)
 
   def generate_acodec_string(audio_codecs) do
@@ -21,7 +57,7 @@ defmodule Pinchflat.Downloading.CodecParser do
     |> Enum.map(&audio_codec_map()[&1])
     |> Enum.reject(&is_nil/1)
     |> Enum.map(&"bestaudio[acodec~='^#{&1}']")
-    |> Enum.concat(["bestaudio", "best"])
+    |> Enum.concat(["bestaudio"])
     |> Enum.join("/")
   end
 
@@ -35,15 +71,10 @@ defmodule Pinchflat.Downloading.CodecParser do
 
   defp audio_codec_map do
     %{
-      "flac" => "flac",
-      "alac" => "alac",
-      "wav" => "wav",
-      "aiff" => "aiff",
       "aac" => "aac",
       "mp4a" => "mp4a",
       "mp3" => "mp3",
-      "opus" => "opus",
-      "vorbis" => "vorbis"
+      "opus" => "opus"
     }
   end
 end

--- a/lib/pinchflat/downloading/codec_parser.ex
+++ b/lib/pinchflat/downloading/codec_parser.ex
@@ -1,0 +1,49 @@
+defmodule Pinchflat.Downloading.CodecParser do
+  # TODO: test
+  def generate_vcodec_string(nil), do: "bestvideo[vcodec~='^avc']/bestvideo"
+  def generate_vcodec_string([]), do: generate_vcodec_string(nil)
+
+  def generate_vcodec_string(video_codecs) do
+    video_codecs
+    |> Enum.map(&video_codec_map()[&1])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&"bestvideo[vcodec~='^#{&1}']")
+    |> Enum.concat(["bestvideo", "best"])
+    |> Enum.join("/")
+  end
+
+  # TODO: test
+  def generate_acodec_string(nil), do: "bestaudio[acodec~='^mp4a']/bestaudio[acodec~='^mp3']/bestaudio"
+  def generate_acodec_string([]), do: generate_acodec_string(nil)
+
+  def generate_acodec_string(audio_codecs) do
+    audio_codecs
+    |> Enum.map(&audio_codec_map()[&1])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&"bestaudio[acodec~='^#{&1}']")
+    |> Enum.concat(["bestaudio", "best"])
+    |> Enum.join("/")
+  end
+
+  defp video_codec_map do
+    %{
+      "av01" => "av01",
+      "avc" => "avc",
+      "vp9" => "vp0?9"
+    }
+  end
+
+  defp audio_codec_map do
+    %{
+      "flac" => "flac",
+      "alac" => "alac",
+      "wav" => "wav",
+      "aiff" => "aiff",
+      "aac" => "aac",
+      "mp4a" => "mp4a",
+      "mp3" => "mp3",
+      "opus" => "opus",
+      "vorbis" => "vorbis"
+    }
+  end
+end

--- a/lib/pinchflat/downloading/codec_parser.ex
+++ b/lib/pinchflat/downloading/codec_parser.ex
@@ -61,7 +61,8 @@ defmodule Pinchflat.Downloading.CodecParser do
     |> Enum.join("/")
   end
 
-  defp video_codec_map do
+  @doc false
+  def video_codec_map do
     %{
       "av01" => "av01",
       "avc" => "avc",
@@ -69,7 +70,8 @@ defmodule Pinchflat.Downloading.CodecParser do
     }
   end
 
-  defp audio_codec_map do
+  @doc false
+  def audio_codec_map do
     %{
       "aac" => "aac",
       "mp4a" => "mp4a",

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -121,38 +121,27 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     end)
   end
 
-  # TODO: test
   defp quality_options(media_profile) do
-    vcodec_string = CodecParser.generate_vcodec_string(["vp9", "av01"])
-    acodec_string = CodecParser.generate_acodec_string(["opus", "aac", "mp4a"])
-
-    video_codec_option = fn res ->
-      [
-        format_sort: "res:#{res}",
-        # Since Plex doesn't support reading metadata from MKV
-        remux_video: "mp4",
-        format: "((#{vcodec_string})+(#{acodec_string}))/best"
-      ]
-    end
-
-    # audio_format_precedence = [
-    #   "bestaudio[ext=m4a]",
-    #   "bestaudio[ext=mp3]",
-    #   "bestaudio",
-    #   "best[ext=m4a]",
-    #   "best[ext=mp3]",
-    #   "best"
-    # ]
+    vcodec_string = CodecParser.generate_vcodec_string_from_settings()
+    acodec_string = CodecParser.generate_acodec_string_from_settings()
 
     case media_profile.preferred_resolution do
       # Also be aware that :audio disabled all embedding options for subtitles
-      :audio -> [:extract_audio, format: "#{acodec_string}/best"]
-      :"360p" -> video_codec_option.("360")
-      :"480p" -> video_codec_option.("480")
-      :"720p" -> video_codec_option.("720")
-      :"1080p" -> video_codec_option.("1080")
-      :"2160p" -> video_codec_option.("2160")
-      :"4320p" -> video_codec_option.("4320")
+      :audio ->
+        [:extract_audio, format: "#{acodec_string}/best"]
+
+      resolution_atom ->
+        {resolution_string, _} =
+          resolution_atom
+          |> Atom.to_string()
+          |> Integer.parse()
+
+        [
+          format_sort: "res:#{resolution_string}",
+          # Since Plex doesn't support reading metadata from MKV
+          remux_video: "mp4",
+          format: "((#{vcodec_string})+(#{acodec_string}))/best"
+        ]
     end
   end
 

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -61,6 +61,7 @@ defmodule Pinchflat.Settings.Setting do
             |> String.split(">")
             |> Enum.map(&String.trim/1)
             |> Enum.reject(&(String.trim(&1) == ""))
+            |> Enum.map(&String.downcase/1)
 
           put_change(changeset, actual_field, new_value)
       end

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -13,7 +13,10 @@ defmodule Pinchflat.Settings.Setting do
     :apprise_version,
     :apprise_server,
     :video_codec_preference,
-    :audio_codec_preference,
+    :audio_codec_preference
+  ]
+
+  @virtual_fields [
     :video_codec_preference_string,
     :audio_codec_preference_string
   ]
@@ -32,14 +35,15 @@ defmodule Pinchflat.Settings.Setting do
 
     field :video_codec_preference, {:array, :string}, default: []
     field :audio_codec_preference, {:array, :string}, default: []
-    field :video_codec_preference_string, :string, virtual: true
-    field :audio_codec_preference_string, :string, virtual: true
+    field :video_codec_preference_string, :string, default: nil, virtual: true
+    field :audio_codec_preference_string, :string, default: nil, virtual: true
   end
 
   @doc false
   def changeset(setting, attrs) do
     setting
     |> cast(attrs, @allowed_fields)
+    |> cast(attrs, @virtual_fields, empty_values: [])
     |> convert_codec_preference_strings()
     |> validate_required(@required_fields)
   end

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -11,7 +11,9 @@ defmodule Pinchflat.Settings.Setting do
     :pro_enabled,
     :yt_dlp_version,
     :apprise_version,
-    :apprise_server
+    :apprise_server,
+    :video_codec_preference,
+    :audio_codec_preference
   ]
 
   @required_fields ~w(
@@ -25,6 +27,11 @@ defmodule Pinchflat.Settings.Setting do
     field :yt_dlp_version, :string
     field :apprise_version, :string
     field :apprise_server, :string
+
+    field :video_codec_preference, {:array, :string}, default: []
+    field :audio_codec_preference, {:array, :string}, default: []
+    field :video_codec_preference_string, :string, virtual: true
+    field :audio_codec_preference_string, :string, virtual: true
   end
 
   @doc false

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -44,7 +44,6 @@ defmodule Pinchflat.Settings.Setting do
     |> validate_required(@required_fields)
   end
 
-  # TODO: test
   defp convert_codec_preference_strings(changeset) do
     fields = [
       video_codec_preference_string: :video_codec_preference,

--- a/lib/pinchflat_web/controllers/media_items/media_item_html.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html.ex
@@ -15,11 +15,10 @@ defmodule PinchflatWeb.MediaItems.MediaItemHTML do
     !!media_item.media_filepath and File.exists?(media_item.media_filepath)
   end
 
-  # TODO: update for new format types
   def media_type(media_item) do
     case Path.extname(media_item.media_filepath) do
       ext when ext in [".mp4", ".webm", ".mkv"] -> :video
-      ext when ext in [".mp3", ".m4a"] -> :audio
+      ext when ext in [".mp3", ".m4a", ".opus"] -> :audio
       _ -> :unknown
     end
   end

--- a/lib/pinchflat_web/controllers/media_items/media_item_html.ex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html.ex
@@ -15,6 +15,7 @@ defmodule PinchflatWeb.MediaItems.MediaItemHTML do
     !!media_item.media_filepath and File.exists?(media_item.media_filepath)
   end
 
+  # TODO: update for new format types
   def media_type(media_item) do
     case Path.extname(media_item.media_filepath) do
       ext when ext in [".mp4", ".webm", ".mkv"] -> :video

--- a/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/media_item_form.html.heex
@@ -9,7 +9,7 @@
     Oops, something went wrong! Please check the errors below.
   </.error>
 
-  <h3 class=" text-2xl text-black dark:text-white">
+  <h3 class="text-2xl text-black dark:text-white">
     General Options
   </h3>
 

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -12,7 +12,6 @@ defmodule PinchflatWeb.Settings.SettingController do
 
   def update(conn, %{"setting" => setting_params}) do
     setting = Settings.record()
-    IO.inspect(setting_params)
 
     case Settings.update_setting(setting, setting_params) do
       {:ok, _} ->

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -12,6 +12,7 @@ defmodule PinchflatWeb.Settings.SettingController do
 
   def update(conn, %{"setting" => setting_params}) do
     setting = Settings.record()
+    IO.inspect(setting_params)
 
     case Settings.update_setting(setting, setting_params) do
       {:ok, _} ->

--- a/lib/pinchflat_web/controllers/settings/setting_html.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html.ex
@@ -1,6 +1,8 @@
 defmodule PinchflatWeb.Settings.SettingHTML do
   use PinchflatWeb, :html
 
+  alias Pinchflat.Downloading.CodecParser
+
   embed_templates "setting_html/*"
 
   @doc """

--- a/lib/pinchflat_web/controllers/settings/setting_html/codec_settings_help.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/codec_settings_help.html.heex
@@ -1,0 +1,17 @@
+<aside>
+  <h2 class="text-xl font-bold mb-2">Codec Preferences</h2>
+  <section class="ml-2 md:ml-4 mb-2 max-w-prose">
+    <section>
+      Available video codecs:
+      <ul class="list-disc ml-8">
+        <li :for={{codec, _} <- CodecParser.video_codec_map()}><%= codec %></li>
+      </ul>
+    </section>
+    <section class="mt-4">
+      Available audio codecs:
+      <ul class="list-disc ml-8">
+        <li :for={{codec, _} <- CodecParser.audio_codec_map()}><%= codec %></li>
+      </ul>
+    </section>
+  </section>
+</aside>

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -15,5 +15,34 @@
     ) %>
   </section>
 
+  <section class="mt-10">
+    <h3 class="text-2xl text-black dark:text-white">
+      Advanced Options
+    </h3>
+
+    <%!-- TODO: add codec docs --%>
+    <.input
+      id="video_codec_preference_string"
+      name="setting[video_codec_preference_string]"
+      value={Enum.join(f[:video_codec_preference].value, ">")}
+      placeholder="avc>vp9>av01"
+      type="text"
+      label="Video Codec Preference"
+      help="Order of preference for video codecs. Separate with >. See below for available codecs TODO"
+      inputclass="font-mono text-sm mr-4"
+    />
+
+    <.input
+      id="audio_codec_preference_string"
+      name="setting[audio_codec_preference_string]"
+      value={Enum.join(f[:audio_codec_preference].value, ">")}
+      placeholder="mp4a>opus>aac"
+      type="text"
+      label="Audio Codec Preference"
+      help="Order of preference for audio codecs. Separate with >. See below for available codecs TODO"
+      inputclass="font-mono text-sm mr-4"
+    />
+  </section>
+
   <.button class="mt-10 mb-4 sm:mb-8 w-full sm:w-auto" rounding="rounded-lg">Save Settings</.button>
 </.simple_form>

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -1,13 +1,24 @@
-<.simple_form :let={f} for={@changeset} action={@action}>
+<.simple_form
+  :let={f}
+  for={@changeset}
+  action={@action}
+  x-data="{ advancedMode: !!JSON.parse(localStorage.getItem('advancedMode')) }"
+  x-init="$watch('advancedMode', value => localStorage.setItem('advancedMode', JSON.stringify(value)))"
+>
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
 
-  <h3 class="mt-2 md:mt-8 text-2xl text-black dark:text-white">
-    Notification Settings
-  </h3>
-
   <section>
+    <section class="flex justify-between items-center mt-4">
+      <h3 class="text-2xl text-black dark:text-white">
+        Notification Settings
+      </h3>
+      <span class="cursor-pointer hover:underline" x-on:click="advancedMode = !advancedMode">
+        Editing Mode: <span x-text="advancedMode ? 'Advanced' : 'Basic'"></span>
+      </span>
+    </section>
+
     <%= live_render(
       @conn,
       Pinchflat.Settings.AppriseServerLive,
@@ -15,33 +26,42 @@
     ) %>
   </section>
 
-  <section class="mt-10">
-    <h3 class="text-2xl text-black dark:text-white">
-      Advanced Options
-    </h3>
+  <section class="mt-10" x-show="advancedMode">
+    <section>
+      <h3 class="text-2xl text-black dark:text-white">
+        Codec Options
+      </h3>
 
-    <%!-- TODO: add codec docs --%>
-    <.input
-      id="video_codec_preference_string"
-      name="setting[video_codec_preference_string]"
-      value={Enum.join(f[:video_codec_preference].value, ">")}
-      placeholder="avc>vp9>av01"
-      type="text"
-      label="Video Codec Preference"
-      help="Order of preference for video codecs. Separate with >. See below for available codecs TODO"
-      inputclass="font-mono text-sm mr-4"
-    />
+      <p class="text-sm mt-2 max-w-prose">
+        The best available codec will be used if your preferred codecs are not found
+      </p>
 
-    <.input
-      id="audio_codec_preference_string"
-      name="setting[audio_codec_preference_string]"
-      value={Enum.join(f[:audio_codec_preference].value, ">")}
-      placeholder="mp4a>opus>aac"
-      type="text"
-      label="Audio Codec Preference"
-      help="Order of preference for audio codecs. Separate with >. See below for available codecs TODO"
-      inputclass="font-mono text-sm mr-4"
-    />
+      <.input
+        id="video_codec_preference_string"
+        name="setting[video_codec_preference_string]"
+        value={Enum.join(f[:video_codec_preference].value, ">")}
+        placeholder="avc>vp9>av01"
+        type="text"
+        label="Video Codec Preference"
+        help="Order of preference for video codecs. Separate with >. Will be remuxed into an MP4 container. See below for available codecs"
+        inputclass="font-mono text-sm mr-4"
+      />
+
+      <.input
+        id="audio_codec_preference_string"
+        name="setting[audio_codec_preference_string]"
+        value={Enum.join(f[:audio_codec_preference].value, ">")}
+        placeholder="mp4a>opus>aac"
+        type="text"
+        label="Audio Codec Preference"
+        help="Order of preference for audio codecs. Separate with >. See below for available codecs"
+        inputclass="font-mono text-sm mr-4"
+      />
+    </section>
+
+    <div class="rounded-sm dark:bg-meta-4 p-4 md:p-6 mt-5">
+      <.codec_settings_help />
+    </div>
   </section>
 
   <.button class="mt-10 mb-4 sm:mb-8 w-full sm:w-auto" rounding="rounded-lg">Save Settings</.button>

--- a/priv/repo/migrations/20240521193719_add_codec_preferences_to_settings.exs
+++ b/priv/repo/migrations/20240521193719_add_codec_preferences_to_settings.exs
@@ -1,0 +1,10 @@
+defmodule Pinchflat.Repo.Migrations.AddCodecPreferencesToSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :video_codec_preference, {:array, :string}, default: []
+      add :audio_codec_preference, {:array, :string}, default: []
+    end
+  end
+end

--- a/test/pinchflat/downloading/codec_parser_test.exs
+++ b/test/pinchflat/downloading/codec_parser_test.exs
@@ -1,0 +1,70 @@
+defmodule Pinchflat.Downloading.CodecParserTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Settings
+  alias Pinchflat.Downloading.CodecParser
+
+  describe "generate_vcodec_string_from_settings/1" do
+    test "returns a default vcodec string when setting isn't set" do
+      Settings.set(video_codec_preference: [])
+
+      assert "bestvideo[vcodec~='^avc']/bestvideo" == CodecParser.generate_vcodec_string_from_settings()
+    end
+
+    test "generates a vcodec string" do
+      Settings.set(video_codec_preference: ["av01"])
+
+      assert "bestvideo[vcodec~='^av01']/bestvideo" == CodecParser.generate_vcodec_string_from_settings()
+    end
+  end
+
+  describe "generate_acodec_string_from_settings/1" do
+    test "returns a default acodec string when setting isn't set" do
+      Settings.set(audio_codec_preference: [])
+
+      assert "bestaudio[acodec~='^mp4a']/bestaudio" == CodecParser.generate_acodec_string_from_settings()
+    end
+
+    test "generates an acodec string" do
+      Settings.set(audio_codec_preference: ["mp3"])
+
+      assert "bestaudio[acodec~='^mp3']/bestaudio" == CodecParser.generate_acodec_string_from_settings()
+    end
+  end
+
+  describe "generate_vcodec_string/1" do
+    test "returns a default vcodec string when nil" do
+      assert "bestvideo[vcodec~='^avc']/bestvideo" == CodecParser.generate_vcodec_string(nil)
+    end
+
+    test "returns a default vcodec string when empty" do
+      assert "bestvideo[vcodec~='^avc']/bestvideo" == CodecParser.generate_vcodec_string([])
+    end
+
+    test "generates a vcodec string" do
+      assert "bestvideo[vcodec~='^av01']/bestvideo" == CodecParser.generate_vcodec_string(["av01"])
+    end
+
+    test "ignores options that don't exist" do
+      assert "bestvideo[vcodec~='^av01']/bestvideo" == CodecParser.generate_vcodec_string(["av01", "foo"])
+    end
+  end
+
+  describe "generate_acodec_string/1" do
+    test "returns a default acodec string when nil" do
+      assert "bestaudio[acodec~='^mp4a']/bestaudio" == CodecParser.generate_acodec_string(nil)
+    end
+
+    test "returns a default acodec string when empty" do
+      assert "bestaudio[acodec~='^mp4a']/bestaudio" == CodecParser.generate_acodec_string([])
+    end
+
+    test "generates an acodec string" do
+      assert "bestaudio[acodec~='^mp3']/bestaudio" == CodecParser.generate_acodec_string(["mp3"])
+    end
+
+    test "ignores options that don't exist" do
+      assert "bestaudio[acodec~='^mp3']/bestaudio" == CodecParser.generate_acodec_string(["mp3", "foo"])
+    end
+  end
+end

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -77,7 +77,9 @@ defmodule Pinchflat.SettingsTest do
 
       assert %Ecto.Changeset{} = Settings.change_setting(setting, %{onboarding: true})
     end
+  end
 
+  describe "change_setting/2 when testing codec preferences" do
     test "converts (video|audio)_codec_preference_string to an array" do
       setting = Settings.record()
 
@@ -91,33 +93,49 @@ defmodule Pinchflat.SettingsTest do
       assert ["avc", "vp9"] = changeset.changes.video_codec_preference
       assert ["aac", "opus"] = changeset.changes.audio_codec_preference
     end
-  end
 
-  test "removes whitespace from (video|audio)_codec_preference" do
-    setting = Settings.record()
+    test "removes whitespace from (video|audio)_codec_preference" do
+      setting = Settings.record()
 
-    new_setting = %{
-      video_codec_preference_string: "  avc  > >  vp9  ",
-      audio_codec_preference_string: "aac> opus "
-    }
+      new_setting = %{
+        video_codec_preference_string: "  avc  > >  vp9  ",
+        audio_codec_preference_string: "aac> opus "
+      }
 
-    changeset = Settings.change_setting(setting, new_setting)
+      changeset = Settings.change_setting(setting, new_setting)
 
-    assert ["avc", "vp9"] = changeset.changes.video_codec_preference
-    assert ["aac", "opus"] = changeset.changes.audio_codec_preference
-  end
+      assert ["avc", "vp9"] = changeset.changes.video_codec_preference
+      assert ["aac", "opus"] = changeset.changes.audio_codec_preference
+    end
 
-  test "downcases (video|audio)_codec_preference" do
-    setting = Settings.record()
+    test "downcases (video|audio)_codec_preference" do
+      setting = Settings.record()
 
-    new_setting = %{
-      video_codec_preference_string: "AVC>VP9",
-      audio_codec_preference_string: "AAC>OPUS"
-    }
+      new_setting = %{
+        video_codec_preference_string: "AVC>VP9",
+        audio_codec_preference_string: "AAC>OPUS"
+      }
 
-    changeset = Settings.change_setting(setting, new_setting)
+      changeset = Settings.change_setting(setting, new_setting)
 
-    assert ["avc", "vp9"] = changeset.changes.video_codec_preference
-    assert ["aac", "opus"] = changeset.changes.audio_codec_preference
+      assert ["avc", "vp9"] = changeset.changes.video_codec_preference
+      assert ["aac", "opus"] = changeset.changes.audio_codec_preference
+    end
+
+    test "an empty value will remove the codec settings" do
+      Settings.set(video_codec_preference: ["avc", "vp9"])
+      Settings.set(audio_codec_preference: ["aac", "opus"])
+      setting = Settings.record()
+
+      new_setting = %{
+        video_codec_preference_string: "",
+        audio_codec_preference_string: ""
+      }
+
+      changeset = Settings.change_setting(setting, new_setting)
+
+      assert [] = changeset.changes.video_codec_preference
+      assert [] = changeset.changes.audio_codec_preference
+    end
   end
 end

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -77,5 +77,33 @@ defmodule Pinchflat.SettingsTest do
 
       assert %Ecto.Changeset{} = Settings.change_setting(setting, %{onboarding: true})
     end
+
+    test "converts (video|audio)_codec_preference_string to an array" do
+      setting = Settings.record()
+
+      new_setting = %{
+        video_codec_preference_string: "avc>vp9",
+        audio_codec_preference_string: "aac>opus"
+      }
+
+      changeset = Settings.change_setting(setting, new_setting)
+
+      assert ["avc", "vp9"] = changeset.changes.video_codec_preference
+      assert ["aac", "opus"] = changeset.changes.audio_codec_preference
+    end
+  end
+
+  test "removes whitespace from (video|audio)_codec_preference" do
+    setting = Settings.record()
+
+    new_setting = %{
+      video_codec_preference_string: "  avc  > >  vp9  ",
+      audio_codec_preference_string: "aac> opus "
+    }
+
+    changeset = Settings.change_setting(setting, new_setting)
+
+    assert ["avc", "vp9"] = changeset.changes.video_codec_preference
+    assert ["aac", "opus"] = changeset.changes.audio_codec_preference
   end
 end

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -106,4 +106,18 @@ defmodule Pinchflat.SettingsTest do
     assert ["avc", "vp9"] = changeset.changes.video_codec_preference
     assert ["aac", "opus"] = changeset.changes.audio_codec_preference
   end
+
+  test "downcases (video|audio)_codec_preference" do
+    setting = Settings.record()
+
+    new_setting = %{
+      video_codec_preference_string: "AVC>VP9",
+      audio_codec_preference_string: "AAC>OPUS"
+    }
+
+    changeset = Settings.change_setting(setting, new_setting)
+
+    assert ["avc", "vp9"] = changeset.changes.video_codec_preference
+    assert ["aac", "opus"] = changeset.changes.audio_codec_preference
+  end
 end


### PR DESCRIPTION
## What's new?

- Adds ability to specify desired codec preferences for video and audio (works toward #252)
  - NOTE: this is intentionally a "soft" preference - the best available codec will be chosen if your preferred codecs aren't available
- Adds "advanced mode" UI to the settings page

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

