### PR TITLE
[Enhancement] Added "other" tab to see media that's not set for download

### DIFF
--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -36,21 +36,28 @@
           <.list_items_from_map map={Map.from_struct(@source)} />
         </div>
       </:tab>
-      <:tab title="Pending Media" id="pending">
+      <:tab title="Pending" id="pending">
         <%= live_render(
           @conn,
           Pinchflat.Sources.MediaItemTableLive,
           session: %{"source_id" => @source.id, "media_state" => "pending"}
         ) %>
       </:tab>
-      <:tab title="Downloaded Media" id="downloaded">
+      <:tab title="Downloaded" id="downloaded">
         <%= live_render(
           @conn,
           Pinchflat.Sources.MediaItemTableLive,
           session: %{"source_id" => @source.id, "media_state" => "downloaded"}
         ) %>
       </:tab>
-      <:tab title="Pending Tasks" id="tasks">
+      <:tab title="Other" id="other">
+        <%= live_render(
+          @conn,
+          Pinchflat.Sources.MediaItemTableLive,
+          session: %{"source_id" => @source.id, "media_state" => "other"}
+        ) %>
+      </:tab>
+      <:tab title="Tasks" id="tasks">
         <%= if match?([_|_], @pending_tasks) do %>
           <.table rows={@pending_tasks} table_class="text-black dark:text-white">
             <:col :let={task} label="Worker">

--- a/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
@@ -4,6 +4,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
   import Phoenix.LiveViewTest
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
+  import Pinchflat.ProfilesFixtures
 
   alias Pinchflat.Sources.MediaItemTableLive
 
@@ -34,10 +35,8 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
 
   describe "media_state" do
     test "shows pending media when pending", %{conn: conn, source: source} do
-      downloaded_media_item = media_item_fixture(source_id: source.id, title: "DL-#{Enum.random(0..9999)}")
-
-      pending_media_item =
-        media_item_fixture(source_id: source.id, media_filepath: nil, title: "P-#{Enum.random(0..9999)}")
+      downloaded_media_item = media_item_fixture(source_id: source.id)
+      pending_media_item = media_item_fixture(source_id: source.id, media_filepath: nil)
 
       {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "pending"))
 
@@ -52,6 +51,21 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
       {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "downloaded"))
 
       assert html =~ downloaded_media_item.title
+      refute html =~ pending_media_item.title
+    end
+
+    test "shows records that aren't pending or downloaded when other", %{conn: conn} do
+      media_profile = media_profile_fixture(shorts_behaviour: :exclude)
+      source = source_fixture(media_profile_id: media_profile.id)
+
+      downloaded_media_item = media_item_fixture(source_id: source.id)
+      pending_media_item = media_item_fixture(source_id: source.id, media_filepath: nil)
+      other_media_item = media_item_fixture(source_id: source.id, media_filepath: nil, short_form_content: true)
+
+      {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "other"))
+
+      assert html =~ other_media_item.title
+      refute html =~ downloaded_media_item.title
       refute html =~ pending_media_item.title
     end
   end

--- a/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
@@ -68,6 +68,14 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
       refute html =~ downloaded_media_item.title
       refute html =~ pending_media_item.title
     end
+
+    test "shows 'Manually Ignored' column when other", %{conn: conn, source: source} do
+      _media_item = media_item_fixture(source_id: source.id, prevent_download: true, media_filepath: nil)
+
+      {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "other"))
+
+      assert html =~ "Manually Ignored?"
+    end
   end
 
   defp create_session(source, media_state \\ "pending") do


### PR DESCRIPTION
## What's new?

- Adds "other" tab to source view to capture media that's not pending or downloaded. This can be media that's explicitly ignored or not picked up due to settings on the source/media profile (resolves #257)
- Updates `MediaItemTableLive` so that all tables are reloaded when one is reloaded

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

