### PR TITLE
[Bugfix] Resolve server error for media items without a description

### DIFF
--- a/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/media_items/media_item_html/show.html.heex
@@ -43,7 +43,7 @@
                     </.subtle_link>
                   </span>
                 </div>
-                <div class="mt-4 text-bodydark">
+                <div :if={@media_item.description} class="mt-4 text-bodydark">
                   <.break_on_newline text={@media_item.description} />
                 </div>
               </aside>

--- a/test/pinchflat_web/controllers/media_item_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_item_controller_test.exs
@@ -14,6 +14,13 @@ defmodule PinchflatWeb.MediaItemControllerTest do
 
       assert html_response(conn, 200) =~ "#{media_item.title}"
     end
+
+    test "renders the page when the media item has no description", %{conn: conn} do
+      media_item = media_item_with_attachments(%{description: nil})
+      conn = get(conn, ~p"/sources/#{media_item.source_id}/media/#{media_item}")
+
+      assert html_response(conn, 200) =~ "#{media_item.title}"
+    end
   end
 
   describe "edit media" do


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Fixes issue where media items without a description were being fed into the `break_on_newline` component which ultimately got mad that `nil` was being passed to `String.split` (resolves #271)

## Any other comments?

N/A


