### PR TITLE
[Enhancement] Render URL attributes as a link

### DIFF
--- a/lib/pinchflat_web/components/core_components.ex
+++ b/lib/pinchflat_web/components/core_components.ex
@@ -644,7 +644,13 @@ defmodule PinchflatWeb.CoreComponents do
       <li :for={{k, v} <- @iterable_attributes} class="mb-2 w-2/3">
         <strong><%= k %>:</strong>
         <code class="inline-block text-sm font-mono text-gray p-0.5 mx-0.5">
-          <%= v %>
+          <%= if is_binary(v) and String.starts_with?(v, "http") do %>
+            <.link class="underline decoration-bodydark decoration-1 hover:decoration-white" href={v} target="_blank">
+              <%= v %>
+            </.link>
+          <% else %>
+            <%= v %>
+          <% end %>
         </code>
       </li>
     </ul>


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Modified the `list_items_from_map()` method to render URL attributes as a hyperlink (that opens in a new tab/window)

## What's fixed?

N/A

## Any other comments?

This is a simple, quality-of-life tweak to turn values such as a Source's `original_url` into a clickable link. This is my first time using Elixir, so feel free to change it however you want. I just didn't want to a request a change without at least giving it a shot myself.

The [Development and Contributing](https://github.com/kieraneglin/pinchflat/wiki/Development-and-Contributing) guidance was very helpful. The only extra steps I had to take were:

1. Create a `.env` file to satisfy Docker Compose
    - `touch .env`
2. Run `yarn install` before running `mix check`
    - Without this, I got the error (`/bin/sh: 1: prettier: not found`)

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
