### PR TITLE
[Enhancement] Add improved output template options for media center apps

### DIFF
--- a/lib/pinchflat/downloading/output_path_builder.ex
+++ b/lib/pinchflat/downloading/output_path_builder.ex
@@ -54,7 +54,11 @@ defmodule Pinchflat.Downloading.OutputPathBuilder do
       "season_from_date" => "%(upload_date>%Y)S",
       "season_episode_from_date" => "s%(upload_date>%Y)Se%(upload_date>%m%d)S",
       "season_episode_index_from_date" => "s%(upload_date>%Y)Se%(upload_date>%m%d)S{{ media_upload_date_index }}",
-      "artist_name" => "%(artist,creator,uploader,uploader_id)S"
+      "artist_name" => "%(artist,creator,uploader,uploader_id)S",
+      "static_season__episode_by_index" => "Season 1/s01e{{ media_playlist_index }}",
+      "season_by_year__episode_by_date" => "Season %(upload_date>%Y)S/s%(upload_date>%Y)Se%(upload_date>%m%d)S",
+      "season_by_year__episode_by_date_and_index" =>
+        "Season %(upload_date>%Y)S/s%(upload_date>%Y)Se%(upload_date>%m%d)S{{ media_upload_date_index }}"
     }
   end
 end

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -53,12 +53,22 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
     ]
   end
 
-  def custom_output_template_options do
+  def media_center_custom_output_template_options do
+    %{
+      season_by_year__episode_by_date: "<code>Season YYYY/sYYYYeMMDD</code>",
+      season_by_year__episode_by_date_and_index:
+        "same as the above but it handles dates better. <strong>This is the recommended option</strong>",
+      static_season__episode_by_index:
+        "<code>Season 1/s01eXX</code> where <code>XX</code> is the video's position in the playlist. Only recommended for playlists (not channels) that don't change"
+    }
+  end
+
+  def other_custom_output_template_options do
     %{
       upload_day: nil,
       upload_month: nil,
       upload_year: nil,
-      upload_yyyy_mm_dd: "the upload date in the format YYYY-MM-DD",
+      upload_yyyy_mm_dd: "the upload date in the format <code>YYYY-MM-DD</code>",
       source_custom_name: "the name of the sources that use this profile",
       source_collection_id: "the YouTube ID of the sources that use this profile",
       source_collection_name:
@@ -66,9 +76,9 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       source_collection_type: "the collection type of the sources using this profile. Either 'channel' or 'playlist'",
       artist_name: "the name of the artist with fallbacks to other uploader fields",
       season_from_date: "alias for upload_year",
-      season_episode_from_date: "the upload date formatted as sYYYYeMMDD",
+      season_episode_from_date: "the upload date formatted as <code>sYYYYeMMDD</code>",
       season_episode_index_from_date:
-        "the upload date formatted as sYYYYeMMDDII where II is an index to prevent date collisions",
+        "the upload date formatted as <code>sYYYYeMMDDII</code> where <code>II</code> is an index to prevent date collisions",
       media_playlist_index:
         "the place of the media item in the playlist. Do not use with channels. May not work if the playlist is updated"
     }
@@ -79,7 +89,6 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       id
       ext
       title
-      fulltitle
       uploader
       channel
       upload_date
@@ -101,7 +110,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
   end
 
   defp media_center_output_template do
-    "/shows/{{ source_custom_name }}/Season {{ season_from_date }}/{{ season_episode_index_from_date }} - {{ title }}.{{ ext }}"
+    "/shows/{{ source_custom_name }}/{{ season_by_year__episode_by_date_and_index }} - {{ title }}.{{ ext }}"
   end
 
   defp audio_output_template do

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/output_template_help.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/output_template_help.html.heex
@@ -1,7 +1,7 @@
 <%!-- The heex HTML formatter is really struggling with this file - I apologize in advance --%>
 <aside>
   <h2 class="text-xl font-bold mb-2">Output Template Syntax</h2>
-  <section class="ml-2 md:ml-4 mb-4 max-w-prose">
+  <section class="ml-2 md:ml-4 mb-4 max-w-prose overflow-auto">
     <p>When generating an output template, you have 3 options for syntax:</p>
     <ul class="list-disc list-inside ml-2 md:ml-5">
       <li>
@@ -46,7 +46,7 @@
   </section>
 
   <h2 class="text-xl font-bold mb-2">Template Options</h2>
-  <section class="ml-2 md:ml-4 mb-4">
+  <section class="ml-2 md:ml-4 mb-4 overflow-auto">
     <p class="max-w-prose">
       Any single-word <code class="text-sm">yt-dlp</code>
       option
@@ -56,16 +56,23 @@
       can be used with the curly braced liquid-style syntax.
       This is just a list of the most common options as well as some custom aliases
     </p>
-    <h3 class="text-lg font-bold mb-2">Custom Aliases</h3>
-    <ul class="list-disc list-inside ml-2 md:ml-5">
-      <li :for={{k, v} <- custom_output_template_options()}>
+    <h3 class="text-lg font-bold my-2">Media Center Custom Aliases</h3>
+    <ul class="list-disc list-inside mb-4 ml-2 md:ml-5 max-w-prose">
+      <li :for={{k, v} <- media_center_custom_output_template_options()} class="mt-1">
         <.inline_code>{{ <%= k %> }}</.inline_code>
-        <span :if={v}>- <%= v %></span>
+        <span :if={v}>- <%= raw(v) %></span>
+      </li>
+    </ul>
+    <h3 class="text-lg font-bold mb-2">Other Custom Aliases</h3>
+    <ul class="list-disc list-inside mb-4 ml-2 md:ml-5 max-w-prose">
+      <li :for={{k, v} <- other_custom_output_template_options()} class="mt-1">
+        <.inline_code>{{ <%= k %> }}</.inline_code>
+        <span :if={v}>- <%= raw(v) %></span>
       </li>
     </ul>
     <h3 class="text-lg font-bold mb-2">Common Options</h3>
     <ul class="list-disc list-inside ml-2 md:ml-5">
-      <li :for={opt <- common_output_template_options()}>
+      <li :for={opt <- common_output_template_options()} class="mt-1">
         <.inline_code>{{ <%= opt %> }}</.inline_code>
       </li>
     </ul>


### PR DESCRIPTION
## What's new?

- Adds new `season_by_year__episode_by_date`, `season_by_year__episode_by_date_and_index`, and `static_season__episode_by_index` output template options
  - Related to #302 and #309

## What's changed?

N/A

## What's fixed?

- Made the output template blurb text slightly more bearable on mobile

## Any other comments?

N/A

