### PR TITLE
Add timeout and retry attempts to build step

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Build and Push
         uses: docker/build-push-action@v5
+        timeout_minutes: 10
+        max_attempts: 3
         with:
           context: .
           file: ./docker/selfhosted.Dockerfile


### PR DESCRIPTION
## What's new?

Failed builds will be re-tried automatically.

## What's changed?

Added `timeout_minutes: 10` and `max_attempts: 3` to the Github Actions workflow file.

## What's fixed?

Future failed builds, hopefully.

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
