### PR TITLE
[Dev] Lock custom FFmpeg to last known good version

### DIFF
--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -27,10 +27,10 @@ RUN apt-get update -y && \
     # Hex and Rebar
     mix local.hex --force && \
     mix local.rebar --force && \
-    # FFmpeg
+    # FFmpeg (latest build that doesn't cause an illegal instruction error for some users - see #347)
     export FFMPEG_DOWNLOAD=$(case ${TARGETPLATFORM:-linux/amd64} in \
-    "linux/amd64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"   ;; \
-    "linux/arm64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz" ;; \
+    "linux/amd64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-08-06-14-10/ffmpeg-N-116541-g5dfc0cc841-linux64-gpl.tar.xz"   ;; \
+    "linux/arm64")   echo "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-08-06-14-10/ffmpeg-N-116541-g5dfc0cc841-linuxarm64-gpl.tar.xz" ;; \
     *)               echo ""        ;; esac) && \
     curl -L ${FFMPEG_DOWNLOAD} --output /tmp/ffmpeg.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz --strip-components=2 --no-anchored -C /usr/local/bin/ "ffmpeg" && \


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Locks FFmpeg to the last version confirmed to not cause an `Illegal instruction` error for some users
  - Resolves #347

## Any other comments?

N/A

