### PR TITLE
Flip Config submenu arrow

### DIFF
--- a/lib/pinchflat_web/components/layouts.ex
+++ b/lib/pinchflat_web/components/layouts.ex
@@ -64,7 +64,7 @@ defmodule PinchflatWeb.Layouts do
           <.icon name={@icon} /> <%= @text %>
         </span>
         <span class="text-bodydark2">
-          <.icon name="hero-chevron-up" x-bind:class="{ 'rotate-180': selected }" />
+          <.icon name="hero-chevron-down" x-bind:class="{ 'rotate-180': selected }" />
         </span>
       </span>
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

The arrow indicating that Config has a submenu / is an accordion is currently facing up when unopened, and down when opened:

![image](https://github.com/user-attachments/assets/b560d9a5-69bc-402e-be2e-0eb6dfeca819)

It's pretty much UI-standard to mark a collapsed menu with an arrow facing down, indicating that it can be _dropped-down_. (also common: the arrow facing ~the menu name~ **away from the menu name**, rotating upwards once opened)

I would link some examples and studies (here's [one](https://www.nngroup.com/articles/accordion-icons)), but I'm pretty sure you know this since...

![image](https://github.com/user-attachments/assets/1859887a-47c8-49e1-8d80-ba0fdfe9084f)

https://github.com/kieraneglin/pinchflat/blob/944d26b57d7f183c63a92ec438531f2e9b7f9deb/lib/pinchflat_web/components/custom_components/button_components.ex#L70-L74

All I have done is change the class name for the chevron symbol to a `down` variant, as used in the code above.

## What's fixed?

N/A

## Any other comments?

I also made a version with the arrow rotated 270° facing the name ("Config"), but it looked wrong. Probably because it was not directly next to the text. **edit**: No. It looked wrong because it's not supposed to face the text, but *away* from the text.

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
