### PR TITLE
[Docs] document that BASE_ROUTE_PATH requires the prefix to be stripped

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you change this setting and it works well for you, please leave a comment on 
 | `ENABLE_IPV6`               | No        | `false`                   | Setting to _any_ non-blank value will enable IPv6                                                                               |
 | `JOURNAL_MODE`              | No        | `wal`                     | Set to `delete` if your config directory is stored on a network share (not recommended)                                         |
 | `TZ_DATA_DIR`               | No        | `/etc/elixir_tzdata_data` | The container path where the timezone database is stored                                                                        |
-| `BASE_ROUTE_PATH`           | No        | `/`                       | The base path for route generation. Useful when running behind certain reverse proxies                                          |
+| `BASE_ROUTE_PATH`           | No        | `/`                       | The base path for route generation. Useful when running behind certain reverse proxies, but prefix must be stripped.            |
 | `YT_DLP_WORKER_CONCURRENCY` | No        | `2`                       | The number of concurrent workers that use `yt-dlp` _per queue_. Set to 1 if you're getting IP limited, otherwise don't touch it |
 
 ## EFF donations


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

Tiny change to the readme to make the reverse proxy config easier to figure out. I had to dig into past PRs and found it in the discussion of #275 to figure it out.

## What's fixed?

N/A

## Any other comments?

N/A

- [X] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
