### PR TITLE
[Enhancement] Improve error message when adding a source who's details can't be queried by URL

### DIFF
--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -186,7 +186,13 @@ defmodule Pinchflat.Sources do
       {:ok, source_details} ->
         add_source_details_by_collection_type(source, changeset, source_details)
 
-      {:error, runner_error, _status_code} ->
+      err ->
+        runner_error =
+          case err do
+            {:error, error_msg, _status_code} -> error_msg
+            {:error, error_msg} -> error_msg
+          end
+
         Ecto.Changeset.add_error(
           changeset,
           :original_url,

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -84,6 +84,7 @@ defmodule Pinchflat.YtDlp.MediaCollection do
          {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
       {:ok, format_source_details(parsed_json)}
     else
+      {:error, %Jason.DecodeError{}} -> {:error, "Error decoding JSON response"}
       err -> err
     end
   end

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -147,6 +147,18 @@ defmodule Pinchflat.SourcesTest do
       assert "could not fetch source details from URL" in errors_on(changeset).original_url
     end
 
+    test "adds an error if the runner succeeds but the result was invalid JSON" do
+      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, "Not JSON"} end)
+
+      valid_attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/channel/abc123"
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Sources.create_source(valid_attrs)
+      assert "could not fetch source details from URL" in errors_on(changeset).original_url
+    end
+
     test "you can specify a custom custom_name" do
       expect(YtDlpRunnerMock, :run, &channel_mock/4)
 

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -133,7 +133,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     test "returns an error if the output is not JSON" do
       expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
 
-      assert {:error, %Jason.DecodeError{}} = MediaCollection.get_source_details(@channel_url)
+      assert {:error, "Error decoding JSON response"} = MediaCollection.get_source_details(@channel_url)
     end
   end
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Adds an error message when a source is added with a URL that `yt-dlp` accepts but can't return any details for (eg: `https://www.youtube.com/feed/subscriptions`)
  - Resolves #404

## What's fixed?

N/A

## Any other comments?

N/A

