### PR TITLE
[Housekeeping] Reinstated container root password rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,6 @@ You _must_ ensure the host directories you've mounted are writable by the user r
 > [!IMPORTANT]
 > It's not recommended to run the container as root. Doing so can create permission issues if other apps need to work with the downloaded media.
 
-> [!TIP]
-> If you need to run any command as root, you can run `su` from the container's shell as there is no password set for the root user.
-
 ### ADVANCED: Storing Pinchflat config directory on a network share
 
 As pointed out in [#137](https://github.com/kieraneglin/pinchflat/issues/137), SQLite doesn't like being run in WAL mode on network shares. If you're running Pinchflat on a network share, you can disable WAL mode by setting the `JOURNAL_MODE` environment variable to `delete`. This will make Pinchflat run in rollback journal mode which is less performant but should work on network shares.

--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -127,17 +127,6 @@ EXPOSE ${PORT}
 # Only copy the final release from the build stage
 COPY --from=builder /app/_build/${MIX_ENV}/rel/pinchflat ./
 
-# NEVER do this if you're running in an environment where you don't trust the user
-# (ie: most environments). This is only acceptable in a self-hosted environment.
-# The user could just run the whole container as root and bypass this anyway so
-# it's not a huge deal.
-# This removes the root password to allow users to assume root if needed. This is
-# preferrable to running the whole container as root so that the files/directories
-# created by the app aren't owned by root and are therefore easier for other users
-# and processes to interact with. If you want to just run the whole container as
-# root, use --user 0:0 or something.
-RUN passwd -d root
-
 HEALTHCHECK --interval=120s --start-period=10s \
   CMD curl --fail http://localhost:${PORT}/healthcheck || exit 1
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Previously, you could assume root with `su`. Now you can't do that and have to instead do something like `docker exec -it --user root pinchflat bash`

## What's fixed?

N/A

## Any other comments?

N/A

