### PR TITLE
[Bugfix] Ensure that `playlist_index` remains persisted in all cases

### DIFF
--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -15,6 +15,9 @@ defmodule Pinchflat.Media do
 
   alias Pinchflat.Lifecycle.UserScripts.CommandRunner, as: UserScriptRunner
 
+  # Some fields should only be set on insert and not on update.
+  @fields_to_drop_on_update [:playlist_index]
+
   @doc """
   Returns the list of media_items.
 
@@ -131,8 +134,6 @@ defmodule Pinchflat.Media do
   """
   def create_media_item_from_backend_attrs(source, media_attrs_struct) do
     attrs = Map.merge(%{source_id: source.id}, Map.from_struct(media_attrs_struct))
-    # Some fields should only be set on insert and not on update.
-    fields_to_drop_on_update = [:playlist_index]
 
     %MediaItem{}
     |> MediaItem.changeset(attrs)
@@ -140,7 +141,7 @@ defmodule Pinchflat.Media do
       on_conflict: [
         set:
           attrs
-          |> Map.drop(fields_to_drop_on_update)
+          |> Map.drop(@fields_to_drop_on_update)
           |> Map.to_list()
       ],
       conflict_target: [:source_id, :media_id]
@@ -153,8 +154,10 @@ defmodule Pinchflat.Media do
   Returns {:ok, %MediaItem{}} | {:error, %Ecto.Changeset{}}
   """
   def update_media_item(%MediaItem{} = media_item, attrs) do
+    update_attrs = Map.drop(attrs, @fields_to_drop_on_update)
+
     media_item
-    |> MediaItem.changeset(attrs)
+    |> MediaItem.changeset(update_attrs)
     |> Repo.update()
   end
 

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -712,6 +712,21 @@ defmodule Pinchflat.MediaTest do
       assert media_item.media_filepath == update_attrs.media_filepath
     end
 
+    test "updating strips playlist_index from the provided attrs" do
+      media_item = media_item_fixture(playlist_index: 5)
+
+      update_attrs = %{
+        media_id: Faker.String.base64(12),
+        title: Faker.Commerce.product_name(),
+        media_filepath: "/video/#{Faker.File.file_name(:video)}",
+        source_id: source_fixture().id,
+        playlist_index: 1
+      }
+
+      assert {:ok, %MediaItem{} = media_item} = Media.update_media_item(media_item, update_attrs)
+      assert media_item.playlist_index == 5
+    end
+
     test "updating with invalid data returns error changeset" do
       media_item = media_item_fixture()
       assert {:error, %Ecto.Changeset{}} = Media.update_media_item(media_item, @invalid_attrs)


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Took the easy way out and specifically omitted `playlist_index` as a field that can be updated
  - Resolves #409

## Any other comments?

N/A

