### PR TITLE
[Enhancement] Improve short detection logic (again)

### DIFF
--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -87,9 +87,11 @@ defmodule Pinchflat.YtDlp.Media do
   Returns the output template for yt-dlp's indexing command.
 
   NOTE: playlist_index is really only useful for playlists that will never change their order.
+  NOTE: I've switched back to `original_url` (from `webpage_url`) since it's started indicating
+        if something is a short via the URL again
   """
   def indexing_output_template do
-    "%(.{id,title,live_status,webpage_url,description,aspect_ratio,duration,upload_date,timestamp,playlist_index})j"
+    "%(.{id,title,live_status,original_url,description,aspect_ratio,duration,upload_date,timestamp,playlist_index})j"
   end
 
   @doc """
@@ -103,17 +105,17 @@ defmodule Pinchflat.YtDlp.Media do
       media_id: response["id"],
       title: response["title"],
       description: response["description"],
-      original_url: response["webpage_url"],
+      original_url: response["original_url"],
       livestream: !!response["live_status"] && response["live_status"] != "not_live",
       duration_seconds: response["duration"] && round(response["duration"]),
-      short_form_content: response["webpage_url"] && short_form_content?(response),
+      short_form_content: response["original_url"] && short_form_content?(response),
       uploaded_at: response["upload_date"] && parse_uploaded_at(response),
       playlist_index: response["playlist_index"] || 0
     }
   end
 
   defp short_form_content?(response) do
-    if String.contains?(response["webpage_url"], "/shorts/") do
+    if String.contains?(response["original_url"], "/shorts/") do
       true
     else
       # Sometimes shorts are returned without /shorts/ in the URL,

--- a/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
@@ -100,7 +100,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
           Phoenix.json_library().encode!(%{
             id: "video2",
             title: "Video 2",
-            webpage_url: "https://example.com/shorts/video2",
+            original_url: "https://example.com/shorts/video2",
             live_status: "is_live",
             description: "desc2",
             aspect_ratio: 1.67,

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -188,7 +188,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
             description: "desc3",
             # Only focusing on these because these are passed to functions that
             # could fail if they're not present
-            webpage_url: nil,
+            original_url: nil,
             aspect_ratio: nil,
             duration: nil,
             upload_date: nil
@@ -299,7 +299,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
           Phoenix.json_library().encode!(%{
             id: "video2",
             title: "Video 2",
-            webpage_url: "https://example.com/shorts/video2",
+            original_url: "https://example.com/shorts/video2",
             live_status: "is_live",
             description: "desc2",
             aspect_ratio: 1.67,

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -139,7 +139,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
   describe "indexing_output_template/0" do
     test "contains all the greatest hits" do
       attrs =
-        ~w(id title live_status webpage_url description aspect_ratio duration upload_date timestamp playlist_index)a
+        ~w(id title live_status original_url description aspect_ratio duration upload_date timestamp playlist_index)a
 
       formatted_attrs = "%(.{#{Enum.join(attrs, ",")}})j"
 
@@ -153,7 +153,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
         "id" => "TiZPUDkDYbk",
         "title" => "Trying to Wheelie Without the Rear Brake",
         "description" => "I'm not sure what I expected.",
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "live_status" => "not_live",
         "aspect_ratio" => 1.0,
         "duration" => 60,
@@ -177,7 +177,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "sets short_form_content to true if the URL contains /shorts/" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/shorts/TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/shorts/TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => "20210101"
@@ -188,7 +188,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "sets short_form_content to true if the aspect ratio are duration are right" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 0.5,
         "duration" => 59,
         "upload_date" => "20210101"
@@ -199,7 +199,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "sets short_form_content to false otherwise" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => "20210101"
@@ -210,7 +210,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "doesn't blow up if short form content-related fields are missing" do
       response = %{
-        "webpage_url" => nil,
+        "original_url" => nil,
         "aspect_ratio" => nil,
         "duration" => nil,
         "upload_date" => "20210101"
@@ -221,7 +221,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "parses the duration" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 60.4,
         "upload_date" => "20210101"
@@ -232,7 +232,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "doesn't blow up if duration is missing" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => nil,
         "upload_date" => "20210101"
@@ -243,7 +243,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "sets livestream to false if the live_status field isn't present" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 60,
         "upload_date" => "20210101"
@@ -254,7 +254,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "doesn't blow up if playlist_index is missing" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => nil,
         "upload_date" => "20210101"
@@ -267,7 +267,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
   describe "response_to_struct/1 when testing uploaded_at" do
     test "parses the upload date from the timestamp if present" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => "20210101",
@@ -281,7 +281,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "parses the upload date from the uploaded_at if timestamp is present but nil" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => "20210101",
@@ -295,7 +295,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "parses the upload date from the uploaded_at if timestamp absent" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => "20210101"
@@ -308,7 +308,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
     test "doesn't blow up if upload date is missing" do
       response = %{
-        "webpage_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
+        "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 1.0,
         "duration" => 61,
         "upload_date" => nil

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -95,7 +95,7 @@ defmodule Pinchflat.MediaFixtures do
     media_attributes = %{
       id: "video1",
       title: "Video 1",
-      webpage_url: "https://example.com/video1",
+      original_url: "https://example.com/video1",
       live_status: "not_live",
       description: "desc1",
       aspect_ratio: 1.67,

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -80,7 +80,7 @@ defmodule Pinchflat.SourcesFixtures do
       %{
         id: "video1",
         title: "Video 1",
-        webpage_url: "https://example.com/video1",
+        original_url: "https://example.com/video1",
         live_status: "not_live",
         description: "desc1",
         aspect_ratio: 1.67,
@@ -90,7 +90,7 @@ defmodule Pinchflat.SourcesFixtures do
       %{
         id: "video2",
         title: "Video 2",
-        webpage_url: "https://example.com/video2",
+        original_url: "https://example.com/video2",
         live_status: "is_live",
         description: "desc2",
         aspect_ratio: 1.67,
@@ -100,7 +100,7 @@ defmodule Pinchflat.SourcesFixtures do
       %{
         id: "video3",
         title: "Video 3",
-        webpage_url: "https://example.com/video3",
+        original_url: "https://example.com/video3",
         live_status: "not_live",
         description: "desc3",
         aspect_ratio: 1.0,


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Reverts #59 so we now use `original_url` in the indexing output template again. I can't remember the reason for the original switch, but it must've increased reliability in detecting shorts. Anyway, since a new bunch of shorts-related issues have cropped up I've switched back since `original_url` now more reliably returns `/shorts/` in the URL when indexing a channel
  - Resolves #415 

## What's fixed?

N/A

## Any other comments?

N/A


