### PR TITLE
[Enhancement] Add support for yt-dlp plugins + add lifecycle script event for app boot

### DIFF
--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -88,6 +88,7 @@ RUN apt-get update -y && \
       ca-certificates \
       python3-mutagen \
       curl \
+      zip \
       openssh-client \
       nano \
       python3 \
@@ -116,7 +117,8 @@ ENV LC_ALL en_US.UTF-8
 WORKDIR "/app"
 
 # Set up data volumes
-RUN mkdir /config /downloads /etc/elixir_tzdata_data && chmod ugo+rw /etc/elixir_tzdata_data
+RUN mkdir -p /config /downloads /etc/elixir_tzdata_data /etc/yt-dlp/plugins && \ 
+  chmod ugo+rw /etc/elixir_tzdata_data /etc/yt-dlp /etc/yt-dlp/plugins
 
 # set runner ENV
 ENV MIX_ENV="prod"

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -98,7 +98,6 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
     Settings.set(apprise_version: apprise_version)
   end
 
-  # TODO: test
   defp run_app_init_script do
     runner = Application.get_env(:pinchflat, :user_script_runner, UserScriptRunner)
 

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -16,6 +16,8 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   alias Pinchflat.Settings
   alias Pinchflat.Utils.FilesystemUtils
 
+  alias Pinchflat.Lifecycle.UserScripts.CommandRunner, as: UserScriptRunner
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, %{}, opts)
   end
@@ -36,6 +38,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
     create_blank_yt_dlp_files()
     create_blank_user_script_file()
     apply_default_settings()
+    run_app_init_script()
 
     {:ok, state}
   end
@@ -93,6 +96,13 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
 
     Settings.set(yt_dlp_version: yt_dlp_version)
     Settings.set(apprise_version: apprise_version)
+  end
+
+  # TODO: test
+  defp run_app_init_script do
+    runner = Application.get_env(:pinchflat, :user_script_runner, UserScriptRunner)
+
+    runner.run(:app_init, %{})
   end
 
   defp yt_dlp_runner do

--- a/lib/pinchflat/lifecycle/user_scripts/command_runner.ex
+++ b/lib/pinchflat/lifecycle/user_scripts/command_runner.ex
@@ -12,6 +12,7 @@ defmodule Pinchflat.Lifecycle.UserScripts.CommandRunner do
   @behaviour UserScriptCommandRunner
 
   @event_types [
+    :app_init,
     :media_pre_download,
     :media_downloaded,
     :media_deleted

--- a/lib/pinchflat/release.ex
+++ b/lib/pinchflat/release.ex
@@ -29,6 +29,8 @@ defmodule Pinchflat.Release do
       [
         "/config",
         "/downloads",
+        "/etc/yt-dlp",
+        "/etc/yt-dlp/plugins",
         Application.get_env(:pinchflat, :media_directory),
         Application.get_env(:pinchflat, :tmpfile_directory),
         Application.get_env(:pinchflat, :extras_directory),

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -9,6 +9,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
   setup do
     stub(YtDlpRunnerMock, :version, fn -> {:ok, "1"} end)
     stub(AppriseRunnerMock, :version, fn -> {:ok, "2"} end)
+    stub(UserScriptRunnerMock, :run, fn _event_type, _data -> {:ok, "3", 0} end)
 
     :ok
   end
@@ -110,6 +111,18 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
       PreJobStartupTasks.init(%{})
 
       assert Settings.get!(:apprise_version)
+    end
+  end
+
+  describe "run_app_init_script" do
+    test "calls the app_init user script runner" do
+      expect(UserScriptRunnerMock, :run, fn :app_init, data ->
+        assert data == %{}
+
+        {:ok, "", 0}
+      end)
+
+      PreJobStartupTasks.init(%{})
     end
   end
 end


### PR DESCRIPTION
## What's new?

**TODO:** Remove draft comment [here](https://github.com/kieraneglin/pinchflat/wiki/%5BAdvanced%5D-yt%E2%80%90dlp-plugins)
**TODO:** Document this new lifecycle event [here](https://github.com/kieraneglin/pinchflat/wiki/%5BAdvanced%5D-Custom-lifecycle-scripts)

- Adds a new `app_init` lifecycle event that can be used in custom lifecycle scripts
  - Can be used to install plugins, among other things
- Adds new in-container directory for holding plugins at `/etc/yt-dlp/plugins`
  - This directory was chosen per the yt-dlp plugin installation [instructions](https://github.com/yt-dlp/yt-dlp#installing-plugins)
- Adds `zip` to the selfhosted Dockerfile's packages to aid in installing plugins programatically  
- Resolves #448

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A