### PR TITLE
[Enhancement] Add option to use existing Media Profile as template for new profile

### DIFF
--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
@@ -31,8 +31,8 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileController do
         Profiles.change_media_profile(%MediaProfile{
           cs_struct
           | id: nil,
-          name: nil,
-          marked_for_deletion_at: nil
+            name: nil,
+            marked_for_deletion_at: nil
         })
     )
   end

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
@@ -17,10 +17,24 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileController do
     render(conn, :index, media_profiles: media_profiles)
   end
 
-  def new(conn, _params) do
-    changeset = Profiles.change_media_profile(%MediaProfile{})
+  def new(conn, params) do
+    # Preload an existing media profile for faster creation
+    cs_struct =
+      case to_string(params["template_id"]) do
+        "" -> %MediaProfile{}
+        template_id -> Repo.get(MediaProfile, template_id) || %MediaProfile{}
+      end
 
-    render(conn, :new, changeset: changeset, layout: get_onboarding_layout())
+    render(conn, :new,
+      layout: get_onboarding_layout(),
+      changeset:
+        Profiles.change_media_profile(%MediaProfile{
+          cs_struct
+          | id: nil,
+          name: nil,
+          marked_for_deletion_at: nil
+        })
+    )
   end
 
   def create(conn, %{"media_profile" => media_profile_params}) do

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -10,6 +10,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
   """
   attr :changeset, Ecto.Changeset, required: true
   attr :action, :string, required: true
+  attr :method, :string, required: true
 
   def media_profile_form(assigns)
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/actions_dropdown.html.heex
@@ -12,6 +12,11 @@
     </span>
   </:option>
   <:option>
+    <.link href={~p"/media_profiles/new?template_id=#{@media_profile}"} method="get">
+      Use as Template
+    </.link>
+  </:option>
+  <:option>
     <div class="h-px w-full bg-bodydark2"></div>
   </:option>
   <:option>

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/edit.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/edit.html.heex
@@ -10,7 +10,7 @@
 <div class="rounded-sm border border-stroke bg-white px-5 pb-2.5 pt-6 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 xl:pb-1">
   <div class="max-w-full">
     <div class="flex flex-col gap-10">
-      <.media_profile_form changeset={@changeset} action={~p"/media_profiles/#{@media_profile}"} />
+      <.media_profile_form changeset={@changeset} action={~p"/media_profiles/#{@media_profile}"} method="patch" />
     </div>
   </div>
 </div>

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -2,6 +2,7 @@
   :let={f}
   for={@changeset}
   action={@action}
+  method={@method}
   x-data="{ advancedMode: !!JSON.parse(localStorage.getItem('advancedMode')) }"
   x-init="$watch('advancedMode', value => localStorage.setItem('advancedMode', JSON.stringify(value)))"
 >

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/new.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/new.html.heex
@@ -8,7 +8,7 @@
 <div class="rounded-sm border border-stroke bg-white px-5 pb-2.5 pt-6 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 xl:pb-1">
   <div class="max-w-full">
     <div class="flex flex-col gap-10">
-      <.media_profile_form changeset={@changeset} action={~p"/media_profiles"} />
+      <.media_profile_form changeset={@changeset} action={~p"/media_profiles"} method="post" />
     </div>
   </div>
 </div>

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -67,7 +67,8 @@ defmodule PinchflatWeb.Sources.SourceController do
             collection_name: nil,
             collection_id: nil,
             collection_type: nil,
-            original_url: nil
+            original_url: nil,
+            marked_for_deletion_at: nil,
         })
     )
   end

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -68,7 +68,7 @@ defmodule PinchflatWeb.Sources.SourceController do
             collection_id: nil,
             collection_type: nil,
             original_url: nil,
-            marked_for_deletion_at: nil,
+            marked_for_deletion_at: nil
         })
     )
   end

--- a/test/pinchflat_web/controllers/media_profile_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_profile_controller_test.exs
@@ -79,6 +79,15 @@ defmodule PinchflatWeb.MediaProfileControllerTest do
 
       refute html_response(conn, 200) =~ "MENU"
     end
+
+    test "preloads some attributes when using a template", %{conn: conn} do
+      profile = media_profile_fixture(name: "My first profile", download_subs: true, sub_langs: "de")
+
+      conn = get(conn, ~p"/media_profiles/new", %{"template_id" => profile.id})
+      assert html_response(conn, 200) =~ "New Media Profile"
+      assert html_response(conn, 200) =~ profile.sub_langs
+      refute html_response(conn, 200) =~ profile.name
+    end
   end
 
   describe "edit media_profile" do


### PR DESCRIPTION
## What's new?

Replicated the "Use as Template" feature from Sources to Media Profiles. Existing profile can now be used as a template to create new profiles as requested in #459. Option can be found under the Actions dropdown in the Media Profile view.

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

There was some weird behavior: It seems like having parameters in the new Profile form fires a PUT request instead of a POST request like it should. To fix that I basically replicated what was done on the Source form and specified explicit methods. All tests are now passing.

Closes #459 

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
