### PR TITLE
[Bugfix] Ensure livestreams aren't downloaded until they're finished processing

### DIFF
--- a/lib/pinchflat/downloading/media_download_worker.ex
+++ b/lib/pinchflat/downloading/media_download_worker.ex
@@ -94,6 +94,10 @@ defmodule Pinchflat.Downloading.MediaDownloadWorker do
       {:recovered, _} ->
         {:error, :retry}
 
+      # TODO: test
+      {:error, :unsuitable_for_download} ->
+        {:ok, :non_retry}
+
       {:error, message} ->
         action_on_error(message)
     end

--- a/lib/pinchflat/downloading/media_download_worker.ex
+++ b/lib/pinchflat/downloading/media_download_worker.ex
@@ -94,7 +94,6 @@ defmodule Pinchflat.Downloading.MediaDownloadWorker do
       {:recovered, _} ->
         {:error, :retry}
 
-      # TODO: test
       {:error, :unsuitable_for_download} ->
         {:ok, :non_retry}
 

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -37,6 +37,14 @@ defmodule Pinchflat.Downloading.MediaDownloader do
       {:ok, parsed_json} ->
         update_media_item_from_parsed_json(media_with_preloads, parsed_json)
 
+      # TODO: test
+      {:error, :unsuitable_for_download} ->
+        Logger.warning(
+          "Media item ##{media_with_preloads.id} isn't suitable for download yet. May be an active or processing live stream"
+        )
+
+        {:error, :unsuitable_for_download}
+
       {:error, message, _exit_code} ->
         Logger.error("yt-dlp download error for media item ##{media_with_preloads.id}: #{inspect(message)}")
 
@@ -108,7 +116,12 @@ defmodule Pinchflat.Downloading.MediaDownloader do
     {:ok, options} = DownloadOptionBuilder.build(item_with_preloads, override_opts)
     runner_opts = [output_filepath: output_filepath, use_cookies: item_with_preloads.source.use_cookies]
 
-    YtDlpMedia.download(url, options, runner_opts)
+    # TODO: test
+    case YtDlpMedia.get_downloadable_status(url) do
+      {:ok, :downloadable} -> YtDlpMedia.download(url, options, runner_opts)
+      {:ok, :ignorable} -> {:error, :unsuitable_for_download}
+      err -> err
+    end
   end
 
   defp recoverable_errors do

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -37,7 +37,6 @@ defmodule Pinchflat.Downloading.MediaDownloader do
       {:ok, parsed_json} ->
         update_media_item_from_parsed_json(media_with_preloads, parsed_json)
 
-      # TODO: test
       {:error, :unsuitable_for_download} ->
         Logger.warning(
           "Media item ##{media_with_preloads.id} isn't suitable for download yet. May be an active or processing live stream"
@@ -116,7 +115,6 @@ defmodule Pinchflat.Downloading.MediaDownloader do
     {:ok, options} = DownloadOptionBuilder.build(item_with_preloads, override_opts)
     runner_opts = [output_filepath: output_filepath, use_cookies: item_with_preloads.source.use_cookies]
 
-    # TODO: test
     case YtDlpMedia.get_downloadable_status(url) do
       {:ok, :downloadable} -> YtDlpMedia.download(url, options, runner_opts)
       {:ok, :ignorable} -> {:error, :unsuitable_for_download}

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -49,7 +49,12 @@ defmodule Pinchflat.YtDlp.Media do
     end
   end
 
-  # TODO: test
+  @doc """
+  Determines if the media at the given URL is ready to be downloaded.
+  Common examples of non-downloadable media are upcoming or in-progress live streams.
+
+  Returns {:ok, :downloadable | :ignorable} | {:error, any}
+  """
   def get_downloadable_status(url) do
     case backend_runner().run(url, [:simulate, :skip_download], "%(.{live_status})j") do
       {:ok, output} ->
@@ -163,6 +168,8 @@ defmodule Pinchflat.YtDlp.Media do
     case response["live_status"] do
       status when status in ["is_live", "is_upcoming", "post_live"] -> {:ok, :ignorable}
       status when status in ["was_live", "not_live"] -> {:ok, :downloadable}
+      # This preserves my tenuous support for non-youtube sources.
+      nil -> {:ok, :downloadable}
       _ -> {:error, "Unknown live status: #{response["live_status"]}"}
     end
   end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Previously, we relied purely on methods like `Media.pending_download?` to determine both if something _should_ be downloaded and if something is _ready_ to be downloaded. It works great for the former, but didn't work as well for the latter (esp. around some edge cases with fast indexing). Now, there's an explicit pre-check in `MediaDownloader` to ensure that the media is actually in a state that it can be downloaded. If it's not, we'll check again _during the next indexing pass (both slow and fast indexing)_ . This could conceivably change in the future but this is a proof-of-concept
  - Resolves #395 
  - Resolves #480

## Any other comments?

N/A