### PR TITLE
truncate table columns via css

### DIFF
--- a/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
@@ -28,9 +28,9 @@ defmodule Pinchflat.Pages.HistoryTableLive do
       </span>
       <div class="max-w-full overflow-x-auto">
         <.table rows={@records} table_class="text-white">
-          <:col :let={media_item} label="Title">
+          <:col :let={media_item} label="Title" class="truncate max-w-xs">
             <.subtle_link href={~p"/sources/#{media_item.source_id}/media/#{media_item}"}>
-              {StringUtils.truncate(media_item.title, 35)}
+              {media_item.title}
             </.subtle_link>
           </:col>
           <:col :let={media_item} label="Upload Date">
@@ -42,9 +42,9 @@ defmodule Pinchflat.Pages.HistoryTableLive do
           <:col :let={media_item} label="Downloaded At">
             {format_datetime(media_item.media_downloaded_at)}
           </:col>
-          <:col :let={media_item} label="Source">
+          <:col :let={media_item} label="Source" class="truncate max-w-xs">
             <.subtle_link href={~p"/sources/#{media_item.source_id}"}>
-              {StringUtils.truncate(media_item.source.custom_name, 35)}
+              {media_item.source.custom_name}
             </.subtle_link>
           </:col>
         </.table>

--- a/lib/pinchflat_web/controllers/pages/page_html/job_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/job_table_live.ex
@@ -21,9 +21,9 @@ defmodule Pinchflat.Pages.JobTableLive do
         <:col :let={task} label="Task">
           {worker_to_task_name(task.job.worker)}
         </:col>
-        <:col :let={task} label="Subject">
+        <:col :let={task} label="Subject" class="truncate max-w-xs">
           <.subtle_link href={task_to_link(task)}>
-            {StringUtils.truncate(task_to_record_name(task), 35)}
+            {task_to_record_name(task)}
           </.subtle_link>
         </:col>
         <:col :let={task} label="Attempt No.">

--- a/lib/pinchflat_web/controllers/searches/search_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/searches/search_html/show.html.heex
@@ -9,9 +9,9 @@
     <div class="flex flex-col gap-10 dark:text-white">
       <%= if match?([_|_], @search_results) do %>
         <.table rows={@search_results} table_class="text-black dark:text-white">
-          <:col :let={result} label="Title">
+          <:col :let={result} label="Title" class="truncate max-w-xs">
             <.subtle_link href={~p"/sources/#{result.source_id}/media/#{result.id}"}>
-              {StringUtils.truncate(result.title, 35)}
+              {result.title}
             </.subtle_link>
           </:col>
           <:col :let={result} label="Excerpt">

--- a/lib/pinchflat_web/controllers/sources/source_html/index_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html/index_table_live.ex
@@ -11,9 +11,9 @@ defmodule PinchflatWeb.Sources.IndexTableLive do
   def render(assigns) do
     ~H"""
     <.table rows={@sources} table_class="text-white">
-      <:col :let={source} label="Name">
+      <:col :let={source} label="Name" class="truncate max-w-xs">
         <.subtle_link href={~p"/sources/#{source.id}"}>
-          {StringUtils.truncate(source.custom_name || source.collection_name, 35)}
+          {source.custom_name || source.collection_name}
         </.subtle_link>
       </:col>
       <:col :let={source} label="Pending">

--- a/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
@@ -46,9 +46,9 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
         </div>
       </header>
       <.table rows={@records} table_class="text-white">
-        <:col :let={media_item} label="Title">
+        <:col :let={media_item} label="Title" class="truncate max-w-xs">
           <.subtle_link href={~p"/sources/#{@source.id}/media/#{media_item.id}"}>
-            {StringUtils.truncate(media_item.title, 50)}
+            {media_item.title}
           </.subtle_link>
         </:col>
         <:col :let={media_item} :if={@media_state == "other"} label="Manually Ignored?">


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Truncating titles in tables via css to allow browser to show more of the title if space is available.
  - closes #506
  - related to #458

## What's fixed?

N/A

## Any other comments?

N/A

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
