### PR TITLE
Separate tabs for pending and downloaded in media history

### DIFF
--- a/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
@@ -58,11 +58,10 @@ defmodule Pinchflat.Pages.HistoryTableLive do
 
   def mount(_params, session, socket) do
     page = 1
-    media_state = session["media_state"]
-    base_query = generate_base_query(media_state)
+    base_query = generate_base_query(session["media_state"])
     pagination_attrs = fetch_pagination_attributes(base_query, page)
 
-    {:ok, assign(socket, Map.merge(pagination_attrs, %{base_query: base_query, media_state: media_state}))}
+    {:ok, assign(socket, Map.merge(pagination_attrs, %{base_query: base_query}))}
   end
 
   def handle_event("page_change", %{"direction" => direction}, %{assigns: assigns} = socket) do
@@ -101,7 +100,7 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   defp generate_base_query("pending") do
     MediaQuery.new()
     |> MediaQuery.require_assoc(:media_profile)
-    |> where(^dynamic(^MediaQuery.downloaded() or ^MediaQuery.pending()))
+    |> where(^dynamic(^MediaQuery.downloaded()))
     |> order_by(desc: :id)
   end
 

--- a/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
@@ -100,7 +100,7 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   defp generate_base_query("pending") do
     MediaQuery.new()
     |> MediaQuery.require_assoc(:media_profile)
-    |> where(^dynamic(^MediaQuery.downloaded()))
+    |> where(^dynamic(^MediaQuery.pending()))
     |> order_by(desc: :id)
   end
 

--- a/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
@@ -56,12 +56,13 @@ defmodule Pinchflat.Pages.HistoryTableLive do
     """
   end
 
-  def mount(_params, _session, socket) do
+  def mount(_params, session, socket) do
     page = 1
-    base_query = generate_base_query()
+    media_state = session["media_state"]
+    base_query = generate_base_query(media_state)
     pagination_attrs = fetch_pagination_attributes(base_query, page)
 
-    {:ok, assign(socket, Map.merge(pagination_attrs, %{base_query: base_query}))}
+    {:ok, assign(socket, Map.merge(pagination_attrs, %{base_query: base_query, media_state: media_state}))}
   end
 
   def handle_event("page_change", %{"direction" => direction}, %{assigns: assigns} = socket) do
@@ -97,10 +98,17 @@ defmodule Pinchflat.Pages.HistoryTableLive do
     |> Repo.preload(:source)
   end
 
-  defp generate_base_query do
+  defp generate_base_query("pending") do
     MediaQuery.new()
     |> MediaQuery.require_assoc(:media_profile)
     |> where(^dynamic(^MediaQuery.downloaded() or ^MediaQuery.pending()))
+    |> order_by(desc: :id)
+  end
+
+  defp generate_base_query("downloaded") do
+    MediaQuery.new()
+    |> MediaQuery.require_assoc(:media_profile)
+    |> where(^dynamic(^MediaQuery.downloaded()))
     |> order_by(desc: :id)
   end
 

--- a/lib/pinchflat_web/controllers/pages/page_html/home.html.heex
+++ b/lib/pinchflat_web/controllers/pages/page_html/home.html.heex
@@ -41,9 +41,22 @@
 
 <div class="rounded-sm border shadow-default border-strokedark bg-boxdark mt-4 p-5">
   <span class="text-2xl font-medium mb-4">Media History</span>
-  <section class="mt-6">
-    {live_render(@conn, Pinchflat.Pages.HistoryTableLive)}
-  </section>
+  <.tabbed_layout>
+    <:tab title="Downloaded" id="downloaded">
+      {live_render(
+        @conn,
+        Pinchflat.Pages.HistoryTableLive,
+        session: %{"media_state" => "downloaded"}
+      )}
+    </:tab>
+    <:tab title="Pending" id="pending">
+      {live_render(
+        @conn,
+        Pinchflat.Pages.HistoryTableLive,
+        session: %{"media_state" => "pending"}
+      )}
+    </:tab>
+  </.tabbed_layout>
 </div>
 
 <div class="rounded-sm border shadow-default border-strokedark bg-boxdark mt-4 p-5">


### PR DESCRIPTION
 - closes #504

## What's new?

N/A

## What's changed?

Media history separated tabs for downloaded and pending media items.

## What's fixed?

N/A

## Any other comments?

N/A

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers

<img width="1398" alt="Bildschirmfoto 2024-12-11 um 21 32 12 1" src="https://github.com/user-attachments/assets/eea62a18-2028-4d0b-862e-e129885ca51f" />

