### PR TITLE
[Housekeeping] Pass the current action when calling the yt-dlp runner

### DIFF
--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -3,6 +3,8 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   Runs yt-dlp commands using the `System.cmd/3` function
   """
 
+  require Logger
+
   alias Pinchflat.Utils.CliUtils
   alias Pinchflat.YtDlp.YtDlpCommandRunner
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
@@ -24,7 +26,8 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   Returns {:ok, binary()} | {:error, output, status}.
   """
   @impl YtDlpCommandRunner
-  def run(url, command_opts, output_template, addl_opts \\ []) do
+  def run(url, action_name, command_opts, output_template, addl_opts \\ []) do
+    Logger.debug("Running yt-dlp command for action: #{action_name}")
     # This approach lets us mock the command for testing
     command = backend_executable()
 

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -41,7 +41,7 @@ defmodule Pinchflat.YtDlp.Media do
   def download(url, command_opts \\ [], addl_opts \\ []) do
     all_command_opts = [:no_simulate] ++ command_opts
 
-    with {:ok, output} <- backend_runner().run(url, all_command_opts, "after_move:%()j", addl_opts),
+    with {:ok, output} <- backend_runner().run(url, :download, all_command_opts, "after_move:%()j", addl_opts),
          {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
       {:ok, parsed_json}
     else
@@ -56,7 +56,7 @@ defmodule Pinchflat.YtDlp.Media do
   Returns {:ok, :downloadable | :ignorable} | {:error, any}
   """
   def get_downloadable_status(url) do
-    case backend_runner().run(url, [:simulate, :skip_download], "%(.{live_status})j") do
+    case backend_runner().run(url, :get_downloadable_status, [:simulate, :skip_download], "%(.{live_status})j") do
       {:ok, output} ->
         output
         |> Phoenix.json_library().decode!()
@@ -78,7 +78,7 @@ defmodule Pinchflat.YtDlp.Media do
 
     # NOTE: it doesn't seem like this command actually returns anything in `after_move` since
     # we aren't downloading the main media file
-    backend_runner().run(url, all_command_opts, "after_move:%()j", addl_opts)
+    backend_runner().run(url, :download_thumbnail, all_command_opts, "after_move:%()j", addl_opts)
   end
 
   @doc """
@@ -92,7 +92,7 @@ defmodule Pinchflat.YtDlp.Media do
     all_command_opts = [:simulate, :skip_download] ++ command_opts
     output_template = indexing_output_template()
 
-    case backend_runner().run(url, all_command_opts, output_template, addl_opts) do
+    case backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts) do
       {:ok, output} ->
         output
         |> Phoenix.json_library().decode!()

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -33,12 +33,13 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     output_filepath = FilesystemUtils.generate_metadata_tmpfile(:json)
     file_listener_handler = Keyword.get(addl_opts, :file_listener_handler, false)
     runner_opts = [output_filepath: output_filepath, use_cookies: use_cookies]
+    action = :get_media_attributes_for_collection
 
     if file_listener_handler do
       file_listener_handler.(output_filepath)
     end
 
-    case runner.run(url, all_command_opts, output_template, runner_opts) do
+    case runner.run(url, action, all_command_opts, output_template, runner_opts) do
       {:ok, output} ->
         parsed_lines =
           output
@@ -82,8 +83,9 @@ defmodule Pinchflat.YtDlp.MediaCollection do
 
     all_command_opts = default_opts ++ command_opts
     output_template = "%(.{channel,channel_id,playlist_id,playlist_title,filename})j"
+    action = :get_source_details
 
-    with {:ok, output} <- backend_runner().run(source_url, all_command_opts, output_template, addl_opts),
+    with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts),
          {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
       {:ok, format_source_details(parsed_json)}
     else
@@ -121,8 +123,9 @@ defmodule Pinchflat.YtDlp.MediaCollection do
 
     all_command_opts = [:skip_download] ++ command_opts
     output_template = "playlist:%()j"
+    action = :get_source_metadata
 
-    with {:ok, output} <- backend_runner().run(source_url, all_command_opts, output_template, addl_opts),
+    with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts),
          {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
       {:ok, parsed_json}
     else

--- a/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
+++ b/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
@@ -6,7 +6,7 @@ defmodule Pinchflat.YtDlp.YtDlpCommandRunner do
   yt-dlp command.
   """
 
-  @callback run(binary(), keyword(), binary()) :: {:ok, binary()} | {:error, binary(), integer()}
-  @callback run(binary(), keyword(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
+  @callback run(binary(), atom(), keyword(), binary()) :: {:ok, binary()} | {:error, binary(), integer()}
+  @callback run(binary(), atom(), keyword(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
   @callback version() :: {:ok, binary()} | {:error, binary()}
 end

--- a/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
@@ -14,7 +14,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
   alias Pinchflat.FastIndexing.FastIndexingHelpers
 
   setup do
-    stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+    stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
       {:ok, media_attributes_return_fixture()}
     end)
 
@@ -83,7 +83,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
     test "passes the source's download options to the yt-dlp runner", %{source: source} do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, opts, _ot, _addl_opts ->
         assert {:output, "/tmp/test/media/%(title)S.%(ext)S"} in opts
         assert {:remux_video, "mp4"} in opts
         {:ok, media_attributes_return_fixture()}
@@ -95,7 +95,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
     test "sets use_cookies if the source uses cookies" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, addl ->
         assert {:use_cookies, true} in addl
 
         {:ok, media_attributes_return_fixture()}
@@ -109,7 +109,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
     test "does not set use_cookies if the source does not use cookies" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, addl ->
         assert {:use_cookies, false} in addl
 
         {:ok, media_attributes_return_fixture()}
@@ -126,7 +126,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
       profile = media_profile_fixture(%{shorts_behaviour: :exclude})
       source = source_fixture(%{media_profile_id: profile.id})
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
         output =
           Phoenix.json_library().encode!(%{
             id: "video2",
@@ -150,7 +150,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
     test "does not blow up if a media item cannot be created", %{source: source} do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
         {:ok, "{}"}
       end)
 
@@ -160,7 +160,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
     test "does not blow up if a media item causes a yt-dlp error", %{source: source} do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
         {:error, "message", 1}
       end)
 

--- a/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
@@ -84,7 +84,10 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       source = source_fixture(fast_index: true)
 
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, render_metadata(:media_metadata)} end)
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
+        {:ok, render_metadata(:media_metadata)}
+      end)
 
       expect(AppriseRunnerMock, :run, fn servers, opts ->
         assert "server_1" = servers
@@ -110,7 +113,11 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       source = source_fixture(fast_index: true, download_media: false)
 
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, render_metadata(:media_metadata)} end)
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
+        {:ok, render_metadata(:media_metadata)}
+      end)
+
       expect(AppriseRunnerMock, :run, 0, fn _servers, _opts -> {:ok, ""} end)
 
       perform_job(FastIndexingWorker, %{id: source.id})
@@ -120,7 +127,11 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       source = source_fixture(fast_index: true, title_filter_regex: "foobar")
 
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, render_metadata(:media_metadata)} end)
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
+        {:ok, render_metadata(:media_metadata)}
+      end)
+
       expect(AppriseRunnerMock, :run, 0, fn _servers, _opts -> {:ok, ""} end)
 
       perform_job(FastIndexingWorker, %{id: source.id})

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -757,7 +757,7 @@ defmodule Pinchflat.MediaTest do
     end
 
     test "does delete the media item's metadata files" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, ""} end)
+      stub(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, _addl -> {:ok, ""} end)
       media_item = Repo.preload(media_item_with_attachments(), [:metadata, :source])
 
       update_attrs = %{
@@ -789,7 +789,7 @@ defmodule Pinchflat.MediaTest do
     end
 
     test "deletes the media item's metadata files" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, ""} end)
+      stub(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, _addl -> {:ok, ""} end)
       media_item = Repo.preload(media_item_with_attachments(), [:metadata, :source])
 
       update_attrs = %{
@@ -875,7 +875,7 @@ defmodule Pinchflat.MediaTest do
     end
 
     test "does not delete the media item's metadata files" do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, ""} end)
+      stub(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, _addl -> {:ok, ""} end)
       media_item = Repo.preload(media_item_with_attachments(), [:metadata, :source])
 
       update_attrs = %{

--- a/test/pinchflat/metadata/metadata_file_helpers_test.exs
+++ b/test/pinchflat/metadata/metadata_file_helpers_test.exs
@@ -62,7 +62,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
 
   describe "download_and_store_thumbnail_for/2" do
     test "returns the filepath", %{media_item: media_item} do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, ""} end)
+      stub(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, _addl -> {:ok, ""} end)
 
       filepath = Helpers.download_and_store_thumbnail_for(media_item)
 
@@ -70,7 +70,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
     end
 
     test "calls yt-dlp with the expected options", %{media_item: media_item} do
-      expect(YtDlpRunnerMock, :run, fn url, opts, ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn url, :download_thumbnail, opts, ot, _addl ->
         assert url == media_item.original_url
         assert ot == "after_move:%()j"
 
@@ -89,7 +89,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
     end
 
     test "sets use_cookies if the source uses cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, addl ->
         assert {:use_cookies, true} in addl
         {:ok, ""}
       end)
@@ -101,7 +101,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
     end
 
     test "does not set use_cookies if the source does not use cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, addl ->
         assert {:use_cookies, false} in addl
         {:ok, ""}
       end)
@@ -113,7 +113,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
     end
 
     test "returns nil if yt-dlp fails", %{media_item: media_item} do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:error, "error"} end)
+      stub(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, _addl -> {:error, "error"} end)
 
       filepath = Helpers.download_and_store_thumbnail_for(media_item)
 

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -174,7 +174,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
 
   describe "index_and_enqueue_download_for_media_items/1" do
     setup do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 
@@ -259,7 +259,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "doesn't blow up if a media item cannot be coerced into a struct", %{source: source} do
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         response =
           Phoenix.json_library().encode!(%{
             id: "video3",
@@ -283,7 +283,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "passes the source's download options to the yt-dlp runner", %{source: source} do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         assert {:output, "/tmp/test/media/%(title)S.%(ext)S"} in opts
         assert {:remux_video, "mp4"} in opts
         {:ok, source_attributes_return_fixture()}
@@ -293,7 +293,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "sets use_cookies if the source uses cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert {:use_cookies, true} in addl_opts
         {:ok, source_attributes_return_fixture()}
       end)
@@ -304,7 +304,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "doesn't set use_cookies if the source doesn't use cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert {:use_cookies, false} in addl_opts
         {:ok, source_attributes_return_fixture()}
       end)
@@ -323,7 +323,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "creates a new media item for everything already in the file", %{source: source} do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
         File.write(filepath, source_attributes_return_fixture())
 
@@ -342,7 +342,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "enqueues a download for everything already in the file", %{source: source} do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
         File.write(filepath, source_attributes_return_fixture())
 
@@ -362,7 +362,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
       source = source_fixture(download_media: false)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
         File.write(filepath, source_attributes_return_fixture())
 
@@ -382,7 +382,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       profile = media_profile_fixture(%{shorts_behaviour: :exclude})
       source = source_fixture(%{media_profile_id: profile.id})
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
 
         contents =
@@ -413,7 +413,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "does not enqueue multiple download jobs for the same media items", %{source: source} do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
         File.write(filepath, source_attributes_return_fixture())
 
@@ -432,7 +432,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "does not blow up if the file returns invalid json", %{source: source} do
       watcher_poll_interval = Application.get_env(:pinchflat, :file_watcher_poll_interval)
 
-      stub(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      stub(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         filepath = Keyword.get(addl_opts, :output_filepath)
         File.write(filepath, "INVALID")
 

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -85,7 +85,7 @@ defmodule Pinchflat.SourcesTest do
 
   describe "create_source/2" do
     test "automatically sets the UUID" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -97,7 +97,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "UUID is not writable by the user" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -110,7 +110,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creates a source and adds name + ID from runner response for channels" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -123,7 +123,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creates a source and adds name + ID for playlists" do
-      expect(YtDlpRunnerMock, :run, &playlist_mock/4)
+      expect(YtDlpRunnerMock, :run, &playlist_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -136,7 +136,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "adds an error if the runner fails" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:error, "some error", 1} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl -> {:error, "some error", 1} end)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -148,7 +148,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "adds an error if the runner succeeds but the result was invalid JSON" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:ok, "Not JSON"} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl -> {:ok, "Not JSON"} end)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -160,7 +160,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "you can specify a custom custom_name" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -174,7 +174,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "friendly name is pulled from collection_name if not specified" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -187,7 +187,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creation enforces uniqueness of collection_id scoped to the media_profile and title regex" do
-      expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, 2, fn _url, :get_source_details, _opts, _ot, _addl ->
         {:ok,
          Phoenix.json_library().encode!(%{
            channel: "some channel name",
@@ -208,7 +208,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creation lets you duplicate collection_ids and profiles as long as the regex is different" do
-      expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, 2, fn _url, :get_source_details, _opts, _ot, _addl ->
         {:ok,
          Phoenix.json_library().encode!(%{
            channel: "some channel name",
@@ -232,7 +232,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creation lets you duplicate collection_ids as long as the media profile is different" do
-      expect(YtDlpRunnerMock, :run, 2, fn _url, _opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, 2, fn _url, :get_source_details, _opts, _ot, _addl ->
         {:ok,
          Phoenix.json_library().encode!(%{
            channel: "some channel name",
@@ -256,8 +256,8 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "collection_type is inferred from source details" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
-      expect(YtDlpRunnerMock, :run, &playlist_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
+      expect(YtDlpRunnerMock, :run, &playlist_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -276,13 +276,13 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creation with invalid data fails fast and does not call the runner" do
-      expect(YtDlpRunnerMock, :run, 0, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, 0, &channel_mock/5)
 
       assert {:error, %Ecto.Changeset{}} = Sources.create_source(@invalid_source_attrs)
     end
 
     test "creation will schedule the indexing task" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -295,7 +295,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creation schedules an index test even if the index frequency is 0" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -309,7 +309,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "fast_index forces the index frequency to be a default value" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -324,7 +324,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "disabling fast index will not change the index frequency" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -339,7 +339,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "creating will kickoff a metadata storage worker" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -356,7 +356,7 @@ defmodule Pinchflat.SourcesTest do
 
   describe "create_source/2 when testing options" do
     test "run_post_commit_tasks: false won't enqueue post-commit tasks" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       valid_attrs = %{
         media_profile_id: media_profile_fixture().id,
@@ -380,7 +380,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "updates with invalid data fails fast and does not call the runner" do
-      expect(YtDlpRunnerMock, :run, 0, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, 0, &channel_mock/5)
 
       source = source_fixture()
 
@@ -388,7 +388,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "updating the original_url will re-fetch the source details for channels" do
-      expect(YtDlpRunnerMock, :run, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
 
       source = source_fixture()
       update_attrs = %{original_url: "https://www.youtube.com/channel/abc123"}
@@ -399,7 +399,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "updating the original_url will re-fetch the source details for playlists" do
-      expect(YtDlpRunnerMock, :run, &playlist_mock/4)
+      expect(YtDlpRunnerMock, :run, &playlist_mock/5)
 
       source = source_fixture()
       update_attrs = %{original_url: "https://www.youtube.com/playlist?list=abc123"}
@@ -410,7 +410,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "not updating the original_url will not re-fetch the source details" do
-      expect(YtDlpRunnerMock, :run, 0, &channel_mock/4)
+      expect(YtDlpRunnerMock, :run, 0, &channel_mock/5)
 
       source = source_fixture()
       update_attrs = %{name: "some updated name"}
@@ -428,7 +428,7 @@ defmodule Pinchflat.SourcesTest do
     end
 
     test "updating will kickoff a metadata storage worker if the original_url changes" do
-      expect(YtDlpRunnerMock, :run, &playlist_mock/4)
+      expect(YtDlpRunnerMock, :run, &playlist_mock/5)
       source = source_fixture()
       update_attrs = %{original_url: "https://www.youtube.com/channel/cba321"}
 
@@ -901,7 +901,7 @@ defmodule Pinchflat.SourcesTest do
     end
   end
 
-  defp playlist_mock(_url, _opts, _ot, _addl) do
+  defp playlist_mock(_url, :get_source_details, _opts, _ot, _addl) do
     {
       :ok,
       Phoenix.json_library().encode!(%{
@@ -913,7 +913,7 @@ defmodule Pinchflat.SourcesTest do
     }
   end
 
-  defp channel_mock(_url, _opts, _ot, _addl) do
+  defp channel_mock(_url, :get_source_details, _opts, _ot, _addl) do
     channel_id = "some_channel_id_#{:rand.uniform(1_000_000)}"
 
     {

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -13,30 +13,30 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
   end
 
   describe "run/4" do
-    test "it returns the output and status when the command succeeds" do
-      assert {:ok, _output} = Runner.run(@media_url, [], "")
+    test "returns the output and status when the command succeeds" do
+      assert {:ok, _output} = Runner.run(@media_url, :foo, [], "")
     end
 
-    test "it includes the media url as the first argument" do
-      assert {:ok, output} = Runner.run(@media_url, [:ignore_errors], "")
+    test "includes the media url as the first argument" do
+      assert {:ok, output} = Runner.run(@media_url, :foo, [:ignore_errors], "")
 
       assert String.contains?(output, "#{@media_url} --ignore-errors")
     end
 
-    test "it automatically includes the --print-to-file flag" do
-      assert {:ok, output} = Runner.run(@media_url, [], "%(id)s")
+    test "automatically includes the --print-to-file flag" do
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "%(id)s")
 
       assert String.contains?(output, "--print-to-file %(id)s /tmp/")
     end
 
-    test "it returns the output and status when the command fails" do
+    test "returns the output and status when the command fails" do
       wrap_executable("/bin/false", fn ->
-        assert {:error, "", 1} = Runner.run(@media_url, [], "")
+        assert {:error, "", 1} = Runner.run(@media_url, :foo, [], "")
       end)
     end
 
     test "optionally lets you specify an output_filepath" do
-      assert {:ok, output} = Runner.run(@media_url, [], "%(id)s", output_filepath: "/tmp/yt-dlp-output.json")
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "%(id)s", output_filepath: "/tmp/yt-dlp-output.json")
 
       assert String.contains?(output, "--print-to-file %(id)s /tmp/yt-dlp-output.json")
     end
@@ -54,7 +54,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     test "includes cookie options when cookies.txt exists and enabled", %{cookie_file: cookie_file} do
       FilesystemUtils.write_p!(cookie_file, "cookie data")
 
-      assert {:ok, output} = Runner.run(@media_url, [], "", use_cookies: true)
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "", use_cookies: true)
 
       assert String.contains?(output, "--cookies #{cookie_file}")
     end
@@ -62,7 +62,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     test "doesn't include cookie options when cookies.txt exists but disabled", %{cookie_file: cookie_file} do
       FilesystemUtils.write_p!(cookie_file, "cookie data")
 
-      assert {:ok, output} = Runner.run(@media_url, [], "", use_cookies: false)
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "", use_cookies: false)
 
       refute String.contains?(output, "--cookies #{cookie_file}")
     end
@@ -70,7 +70,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     test "doesn't include cookie options when cookies.txt blank", %{cookie_file: cookie_file} do
       FilesystemUtils.write_p!(cookie_file, " \n \n ")
 
-      assert {:ok, output} = Runner.run(@media_url, [], "", use_cookies: true)
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "", use_cookies: true)
 
       refute String.contains?(output, "--cookies")
       refute String.contains?(output, cookie_file)
@@ -79,7 +79,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     test "doesn't include cookie options when cookies.txt doesn't exist", %{cookie_file: cookie_file} do
       File.rm(cookie_file)
 
-      assert {:ok, output} = Runner.run(@media_url, [], "")
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "")
 
       refute String.contains?(output, "--cookies")
       refute String.contains?(output, cookie_file)
@@ -91,19 +91,19 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
 
   describe "run/4 when testing global options" do
     test "creates windows-safe filenames" do
-      assert {:ok, output} = Runner.run(@media_url, [], "")
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "")
 
       assert String.contains?(output, "--windows-filenames")
     end
 
     test "runs quietly" do
-      assert {:ok, output} = Runner.run(@media_url, [], "")
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "")
 
       assert String.contains?(output, "--quiet")
     end
 
     test "sets the cache directory" do
-      assert {:ok, output} = Runner.run(@media_url, [], "")
+      assert {:ok, output} = Runner.run(@media_url, :foo, [], "")
 
       assert String.contains?(output, "--cache-dir /tmp/test/tmpfiles/yt-dlp-cache")
     end

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -10,7 +10,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
   describe "get_media_attributes_for_collection/2" do
     test "returns a list of video attributes with no blank elements" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture() <> "\n\n"}
       end)
 
@@ -19,7 +19,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes the expected default args" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, ot, _addl_opts ->
         assert opts == [:simulate, :skip_download, :ignore_no_formats_error, :no_warnings]
         assert ot == Media.indexing_output_template()
 
@@ -30,13 +30,15 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "returns the error straight through when the command fails" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:error, "Big issue", 1} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:error, "Big issue", 1}
+      end)
 
       assert {:error, "Big issue", 1} = MediaCollection.get_media_attributes_for_collection(@channel_url)
     end
 
     test "passes long additional command options" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         assert :foo in opts
 
         {:ok, ""}
@@ -46,7 +48,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes additional args to runner" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert [{:output_filepath, filepath} | _] = addl_opts
         assert {:use_cookies, false} in addl_opts
         assert String.ends_with?(filepath, ".json")
@@ -58,7 +60,10 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "supports an optional file_listener_handler that gets passed a filename" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:ok, ""}
+      end)
+
       current_self = self()
 
       handler = fn filename ->
@@ -73,7 +78,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "gracefully handles partially failed responses" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, "INVALID\n\n" <> source_attributes_return_fixture() <> "\nINVALID\n"}
       end)
 
@@ -84,7 +89,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
   describe "get_source_details/1" do
     test "returns a map with data on success" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl_opts ->
         Phoenix.json_library().encode(%{
           channel: "PinchflatTestChannel",
           channel_id: "UCQH2",
@@ -104,7 +109,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes the expected args to the runner" do
-      expect(YtDlpRunnerMock, :run, fn @channel_url, opts, ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn @channel_url, :get_source_details, opts, ot, _addl_opts ->
         assert opts == [:simulate, :skip_download, :ignore_no_formats_error, playlist_end: 1]
         assert ot == "%(.{channel,channel_id,playlist_id,playlist_title,filename})j"
 
@@ -115,7 +120,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes custom args to the runner" do
-      expect(YtDlpRunnerMock, :run, fn @channel_url, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn @channel_url, :get_source_details, opts, _ot, _addl_opts ->
         assert {:foo, :bar} in opts
 
         {:ok, "{}"}
@@ -125,7 +130,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes additional args to the runner" do
-      expect(YtDlpRunnerMock, :run, fn @channel_url, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn @channel_url, :get_source_details, _opts, _ot, addl_opts ->
         assert {:use_cookies, true} in addl_opts
 
         {:ok, "{}"}
@@ -135,13 +140,13 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "returns an error if the runner returns an error" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:error, "Big issue", 1} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl_opts -> {:error, "Big issue", 1} end)
 
       assert {:error, "Big issue", 1} = MediaCollection.get_source_details(@channel_url)
     end
 
     test "returns an error if the output is not JSON" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
 
       assert {:error, "Error decoding JSON response"} = MediaCollection.get_source_details(@channel_url)
     end
@@ -149,7 +154,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
 
   describe "get_source_metadata/1" do
     test "returns a map with data on success" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_metadata, _opts, _ot, _addl_opts ->
         Phoenix.json_library().encode(%{channel: "PinchflatTestChannel"})
       end)
 
@@ -159,7 +164,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes the expected args to the backend runner" do
-      expect(YtDlpRunnerMock, :run, fn @channel_url, opts, ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn @channel_url, :get_source_metadata, opts, ot, _addl_opts ->
         assert opts == [:skip_download, playlist_items: 0]
         assert ot == "playlist:%()j"
 
@@ -170,7 +175,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes additional args to the runner" do
-      expect(YtDlpRunnerMock, :run, fn @channel_url, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn @channel_url, :get_source_metadata, _opts, _ot, addl_opts ->
         assert {:use_cookies, true} in addl_opts
 
         {:ok, "{}"}
@@ -180,7 +185,7 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "passes custom args to the runner" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_metadata, opts, _ot, _addl_opts ->
         assert opts == [:skip_download, playlist_items: 1, real_opt: :yup]
 
         {:ok, "{}"}
@@ -196,13 +201,15 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     end
 
     test "returns an error if the runner returns an error" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:error, "Big issue", 1} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_metadata, _opts, _ot, _addl_opts ->
+        {:error, "Big issue", 1}
+      end)
 
       assert {:error, "Big issue", 1} = MediaCollection.get_source_metadata(@channel_url, playlist_items: 0)
     end
 
     test "returns an error if the output is not JSON" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_metadata, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
 
       assert {:error, %Jason.DecodeError{}} = MediaCollection.get_source_metadata(@channel_url, playlist_items: 0)
     end

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -9,7 +9,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
   describe "download/3" do
     test "calls the backend runner with the expected arguments" do
-      expect(YtDlpRunnerMock, :run, fn @media_url, opts, ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn @media_url, :download, opts, ot, addl ->
         assert [:no_simulate] = opts
         assert "after_move:%()j" = ot
         assert addl == []
@@ -21,7 +21,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along custom command args" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download, opts, _ot, _addl ->
         assert [:no_simulate, :custom_arg] = opts
 
         {:ok, "{}"}
@@ -31,7 +31,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along additional options" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download, _opts, _ot, addl ->
         assert [addl_arg: true] = addl
 
         {:ok, "{}"}
@@ -41,7 +41,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "parses and returns the generated file as JSON" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download, _opts, _ot, _addl ->
         {:ok, render_metadata(:media_metadata)}
       end)
 
@@ -50,7 +50,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns errors" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opt, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download, _opt, _ot, _addl ->
         {:error, "something"}
       end)
 
@@ -60,7 +60,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
   describe "get_downloadable_status/1" do
     test "returns :downloadable if the media was never live" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "not_live"})}
       end)
 
@@ -68,7 +68,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :downloadable if the media was live and has been processed" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "was_live"})}
       end)
 
@@ -76,7 +76,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :downloadable if the media's live_status is nil" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => nil})}
       end)
 
@@ -84,7 +84,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media is currently live" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "is_live"})}
       end)
 
@@ -92,7 +92,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media is scheduled to be live" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "is_upcoming"})}
       end)
 
@@ -100,7 +100,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media was live but hasn't been processed" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "post_live"})}
       end)
 
@@ -108,7 +108,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns an error if the downloadable status can't be determined" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "what_tha"})}
       end)
 
@@ -118,7 +118,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
   describe "download_thumbnail/2" do
     test "calls the backend runner with the expected arguments" do
-      expect(YtDlpRunnerMock, :run, fn @media_url, opts, ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn @media_url, :download_thumbnail, opts, ot, _addl ->
         assert opts == [:no_simulate, :skip_download, :write_thumbnail, {:convert_thumbnail, "jpg"}]
         assert ot == "after_move:%()j"
 
@@ -129,7 +129,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along custom command args" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, opts, _ot, _addl ->
         assert :custom_arg in opts
 
         {:ok, "{}"}
@@ -139,7 +139,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along additional options" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opts, _ot, addl ->
         assert [addl_arg: true] = addl
 
         {:ok, "{}"}
@@ -149,7 +149,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns errors" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opt, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :download_thumbnail, _opt, _ot, _addl ->
         {:error, "something"}
       end)
 
@@ -159,7 +159,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
   describe "get_media_attributes/1" do
     test "returns a list of video attributes" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
         {:ok, media_attributes_return_fixture()}
       end)
 
@@ -168,7 +168,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "it passes the expected default args" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, opts, ot, _addl ->
         assert opts == [:simulate, :skip_download]
         assert ot == Media.indexing_output_template()
 
@@ -179,7 +179,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along additional command options" do
-      expect(YtDlpRunnerMock, :run, fn _url, opts, _ot, _addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, opts, _ot, _addl ->
         assert [:simulate, :skip_download, :custom_arg] = opts
         {:ok, media_attributes_return_fixture()}
       end)
@@ -188,7 +188,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "passes along additional options" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, addl ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, addl ->
         assert [addl_arg: true] = addl
         {:ok, media_attributes_return_fixture()}
       end)
@@ -197,7 +197,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns the error straight through when the command fails" do
-      expect(YtDlpRunnerMock, :run, fn _url, _opts, _ot, _addl -> {:error, "Big issue", 1} end)
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl -> {:error, "Big issue", 1} end)
 
       assert {:error, "Big issue", 1} = Media.get_media_attributes(@media_url)
     end

--- a/test/pinchflat_web/controllers/pages/job_table_live_test.exs
+++ b/test/pinchflat_web/controllers/pages/job_table_live_test.exs
@@ -6,7 +6,6 @@ defmodule PinchflatWeb.Pages.JobTableLiveTest do
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
 
-  alias Pinchflat.Utils.StringUtils
   alias Pinchflat.Pages.JobTableLive
   alias Pinchflat.Downloading.MediaDownloadWorker
   alias Pinchflat.FastIndexing.FastIndexingWorker

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -66,7 +66,7 @@ defmodule PinchflatWeb.SourceControllerTest do
 
   describe "create source" do
     test "redirects to show when data is valid", %{conn: conn, create_attrs: create_attrs} do
-      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/4)
+      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/5)
       conn = post(conn, ~p"/sources", source: create_attrs)
 
       assert %{id: id} = redirected_params(conn)
@@ -82,7 +82,7 @@ defmodule PinchflatWeb.SourceControllerTest do
     end
 
     test "redirects to onboarding when onboarding", %{conn: conn, create_attrs: create_attrs} do
-      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/4)
+      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/5)
 
       Settings.set(onboarding: true)
       conn = post(conn, ~p"/sources", source: create_attrs)
@@ -111,7 +111,7 @@ defmodule PinchflatWeb.SourceControllerTest do
     setup [:create_source]
 
     test "redirects when data is valid", %{conn: conn, source: source, update_attrs: update_attrs} do
-      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/4)
+      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/5)
 
       conn = put(conn, ~p"/sources/#{source}", source: update_attrs)
       assert redirected_to(conn) == ~p"/sources/#{source}"
@@ -276,7 +276,7 @@ defmodule PinchflatWeb.SourceControllerTest do
     %{source: source, media_item: media_item}
   end
 
-  defp runner_function_mock(_url, _opts, _ot, _addl) do
+  defp runner_function_mock(_url, :get_source_details, _opts, _ot, _addl) do
     {
       :ok,
       Phoenix.json_library().encode!(%{


### PR DESCRIPTION
## What's new?

- All calls to the yt-dlp runner now pass an `action` argument where the action is typically the current method name
  - This resolves a long-standing issue with the way yt-dlp is mocked in tests. Since there's only one "entrypoint" into yt-dlp, it made mocking with Mox extremely error prone and fragile since mocks would have to either abuse the fact that _some_ yt-dlp calls had different arity or pattern match against things like the output template. The new approach allows me to match based on the _action_ being taken (a proxy for a method name in a more typical setup) and now I can be sure that I'm mocking the correct thing and I don't have to resort to sketchy bodges. Again, this isn't typically an issue but it was in this case since the `run` method is essentially an opaque entrypoint into a whole host of _other_ functions. 
  I was resistant to this change for a while since it places a pure testing concern into my app's code, but I'm okay with it after seeing the new API it presents. Besides, its surface area is small since I have a delegation layer for these calls
  - Adds logging of the current action
  - Updates a _lot_ of tests
  - Pre-req for #509 
 
## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

