### PR TITLE
[Bugfix] Respect cookies preference when performing download pre-check

### DIFF
--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -116,7 +116,6 @@ defmodule Pinchflat.Downloading.MediaDownloader do
     use_cookies = item_with_preloads.source.use_cookies
     runner_opts = [output_filepath: output_filepath, use_cookies: use_cookies]
 
-    # TODO: test
     case YtDlpMedia.get_downloadable_status(url, use_cookies: use_cookies) do
       {:ok, :downloadable} -> YtDlpMedia.download(url, options, runner_opts)
       {:ok, :ignorable} -> {:error, :unsuitable_for_download}

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -113,9 +113,11 @@ defmodule Pinchflat.Downloading.MediaDownloader do
 
   defp download_with_options(url, item_with_preloads, output_filepath, override_opts) do
     {:ok, options} = DownloadOptionBuilder.build(item_with_preloads, override_opts)
-    runner_opts = [output_filepath: output_filepath, use_cookies: item_with_preloads.source.use_cookies]
+    use_cookies = item_with_preloads.source.use_cookies
+    runner_opts = [output_filepath: output_filepath, use_cookies: use_cookies]
 
-    case YtDlpMedia.get_downloadable_status(url) do
+    # TODO: test
+    case YtDlpMedia.get_downloadable_status(url, use_cookies: use_cookies) do
       {:ok, :downloadable} -> YtDlpMedia.download(url, options, runner_opts)
       {:ok, :ignorable} -> {:error, :unsuitable_for_download}
       err -> err

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -55,8 +55,11 @@ defmodule Pinchflat.YtDlp.Media do
 
   Returns {:ok, :downloadable | :ignorable} | {:error, any}
   """
-  def get_downloadable_status(url) do
-    case backend_runner().run(url, :get_downloadable_status, [:simulate, :skip_download], "%(.{live_status})j") do
+  def get_downloadable_status(url, addl_opts \\ []) do
+    action = :get_downloadable_status
+    command_opts = [:simulate, :skip_download]
+
+    case backend_runner().run(url, action, command_opts, "%(.{live_status})j", addl_opts) do
       {:ok, output} ->
         output
         |> Phoenix.json_library().decode!()

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -60,7 +60,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
   describe "get_downloadable_status/1" do
     test "returns :downloadable if the media was never live" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "not_live"})}
       end)
 
@@ -68,7 +68,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :downloadable if the media was live and has been processed" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "was_live"})}
       end)
 
@@ -76,7 +76,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :downloadable if the media's live_status is nil" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => nil})}
       end)
 
@@ -84,7 +84,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media is currently live" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "is_live"})}
       end)
 
@@ -92,7 +92,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media is scheduled to be live" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "is_upcoming"})}
       end)
 
@@ -100,7 +100,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns :ignorable if the media was live but hasn't been processed" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "post_live"})}
       end)
 
@@ -108,11 +108,21 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
 
     test "returns an error if the downloadable status can't be determined" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot ->
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, Phoenix.json_library().encode!(%{"live_status" => "what_tha"})}
       end)
 
       assert {:error, "Unknown live status: what_tha"} = Media.get_downloadable_status(@media_url)
+    end
+
+    test "optionally accepts additional args" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, addl ->
+        assert [addl_arg: true] = addl
+
+        {:ok, Phoenix.json_library().encode!(%{"live_status" => "not_live"})}
+      end)
+
+      assert {:ok, :downloadable} = Media.get_downloadable_status(@media_url, addl_arg: true)
     end
   end
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Updates the media download pre-check to use the same cookie rules as would be used to actually download the media
  - Resolves #509

## Any other comments?

N/A


