### PR TITLE
OPML "secret" Route

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,7 @@ config :pinchflat,
   # If either is unset, basic auth will not be used.
   basic_auth_username: "",
   basic_auth_password: "",
+  route_secret: "",
   expose_feed_endpoints: false,
   file_watcher_poll_interval: 1000,
   timezone: "UTC",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,7 +23,8 @@ end
 
 config :pinchflat,
   basic_auth_username: System.get_env("BASIC_AUTH_USERNAME"),
-  basic_auth_password: System.get_env("BASIC_AUTH_PASSWORD")
+  basic_auth_password: System.get_env("BASIC_AUTH_PASSWORD"),
+  route_secret: System.get_env("ROUTE_SECRET")
 
 arch_string = to_string(:erlang.system_info(:system_architecture))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ services:
     command: bash -c "chmod +x docker/docker-run.dev.sh && docker/docker-run.dev.sh"
     stdin_open: true
     tty: true
+    environment:
+      - ROUTE_SECRET=J8vaF1t

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -44,7 +44,7 @@ defmodule PinchflatWeb.Sources.SourceHTML do
   end
 
   def opml_feed_url(conn) do
-    url(conn, ~p"/sources/opml") <> ".xml"
+    url(conn, ~p"/secret/#{Application.get_env(:pinchflat, :route_secret)}/opml/feed") <> ".xml"
   end
 
   def output_path_template_override_placeholders(media_profiles) do

--- a/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
@@ -1,7 +1,11 @@
 <div class="mb-6 flex gap-3 flex-row items-center justify-between">
   <h2 class="text-title-md2 font-bold text-black dark:text-white">Sources</h2>
   <nav>
-    <.button :if={Application.get_env(:pinchflat, :route_secret)} color="bg-transparent" x-data="{ copied: false }" x-on:click={~s"
+    <.button
+        :if={Application.get_env(:pinchflat, :route_secret)}
+        color="bg-transparent"
+        x-data="{ copied: false }"
+        x-on:click={~s"
           copyWithCallbacks(
             '#{opml_feed_url(@conn)}',
             () => copied = true,

--- a/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
@@ -1,7 +1,7 @@
 <div class="mb-6 flex gap-3 flex-row items-center justify-between">
   <h2 class="text-title-md2 font-bold text-black dark:text-white">Sources</h2>
   <nav>
-    <.button color="bg-transparent" x-data="{ copied: false }" x-on:click={~s"
+    <.button :if={Application.get_env(:pinchflat, :route_secret)} color="bg-transparent" x-data="{ copied: false }" x-on:click={~s"
           copyWithCallbacks(
             '#{opml_feed_url(@conn)}',
             () => copied = true,

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -23,12 +23,20 @@ defmodule PinchflatWeb.Router do
     plug :maybe_basic_auth
   end
 
+  pipeline :protected_feeds do
+    plug :basic_auth
+  end
+
+  scope "/", PinchflatWeb do
+    pipe_through :protected_feeds
+    # has to match before /sources/:id
+    get "/sources/opml", Podcasts.PodcastController, :opml_feed
+  end
+
   # Routes in here _may not be_ protected by basic auth. This is necessary for
   # media streaming to work for RSS podcast feeds.
   scope "/", PinchflatWeb do
     pipe_through :feeds
-    # has to match before /sources/:id
-    get "/sources/opml", Podcasts.PodcastController, :opml_feed
 
     get "/sources/:uuid/feed", Podcasts.PodcastController, :rss_feed
     get "/sources/:uuid/feed_image", Podcasts.PodcastController, :feed_image

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -29,7 +29,6 @@ defmodule PinchflatWeb.Router do
 
   scope "/secret/:secret", PinchflatWeb do
     pipe_through :secret
-    # has to match before /sources/:id
     get "/opml/feed", Podcasts.PodcastController, :opml_feed
   end
 

--- a/test/pinchflat_web/controllers/podcast_controller_test.exs
+++ b/test/pinchflat_web/controllers/podcast_controller_test.exs
@@ -5,10 +5,23 @@ defmodule PinchflatWeb.PodcastControllerTest do
   import Pinchflat.SourcesFixtures
 
   describe "opml_feed" do
+
+    test "unauthorized when no secret set", %{conn: conn} do
+      Application.put_env(:pinchflat, :route_secret, "")
+      conn = get(conn, ~p"/secret/the-secret/opml/feed" <> ".xml")
+      assert conn.status == 401
+    end
+
+    test "unauthorized when secret incorrect", %{conn: conn} do
+      Application.put_env(:pinchflat, :route_secret, "test-secret")
+      conn = get(conn, ~p"/secret/invalid-secret/opml/feed" <> ".xml")
+      assert conn.status == 401
+    end
+
     test "renders the XML document", %{conn: conn} do
       source = source_fixture()
-
-      conn = get(conn, ~p"/sources/opml" <> ".xml")
+      Application.put_env(:pinchflat, :route_secret, "test-secret")
+      conn = get(conn, ~p"/secret/test-secret/opml/feed" <> ".xml")
 
       assert conn.status == 200
       assert {"content-type", "application/opml+xml; charset=utf-8"} in conn.resp_headers


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

Add the possibility to set a env variable to define the secret OPML feed route. 
Only show "Copy OPML Feed" when the secret is set.
Only allow access to opml route when secret ist set and passed correctly.

#532 

## What's fixed?

N/A

## Any other comments?

N/A

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
