### PR TITLE
[Enhancement] Add media profile, source, and media item IDs as options for output templates

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -201,6 +201,9 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     source = media_item_with_preloads.source
 
     %{
+      "media_item_id" => to_string(media_item_with_preloads.id),
+      "source_id" => to_string(source.id),
+      "media_profile_id" => to_string(source.media_profile_id),
       "source_custom_name" => source.custom_name,
       "source_collection_id" => source.collection_id,
       "source_collection_name" => source.collection_name,

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -57,7 +57,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
   end
 
   def media_center_custom_output_template_options do
-    %{
+    [
       season_by_year__episode_by_date: "<code>Season YYYY/sYYYYeMMDD</code>",
       season_by_year__episode_by_date_and_index:
         "same as the above but it handles dates better. <strong>This is the recommended option</strong>",
@@ -65,11 +65,11 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
         "<code>Season 1/s01eXX</code> where <code>XX</code> is the video's position in the playlist. Only recommended for playlists (not channels) that don't change",
       static_season__episode_by_date:
         "<code>Season 1/s01eYYMMDD</code>. Recommended for playlists that might change or where order isn't important"
-    }
+    ]
   end
 
   def other_custom_output_template_options do
-    %{
+    [
       upload_day: nil,
       upload_month: nil,
       upload_year: nil,
@@ -85,8 +85,11 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       season_episode_index_from_date:
         "the upload date formatted as <code>sYYYYeMMDDII</code> where <code>II</code> is an index to prevent date collisions",
       media_playlist_index:
-        "the place of the media item in the playlist. Do not use with channels. May not work if the playlist is updated"
-    }
+        "the place of the media item in the playlist. Do not use with channels. May not work if the playlist is updated",
+      media_item_id: "the ID of the media item in Pinchflat's database",
+      source_id: "the ID of the source in Pinchflat's database",
+      media_profile_id: "the ID of the media profile in Pinchflat's database"
+    ]
   end
 
   def common_output_template_options do


### PR DESCRIPTION
## What's new?

- Adds `{{ media_profile_id }}`, `{{ source_id }}`, and `{{ media_item_id }}` as options to the output template builder. Can be used to split media into "seasons" based on ID (usually the source ID). See #534 for rationale
  - Resolves #534

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

