### PR TITLE
[Housekeeping] Update Docker healthcheck to run every 30s

### DIFF
--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -129,7 +129,7 @@ EXPOSE ${PORT}
 # Only copy the final release from the build stage
 COPY --from=builder /app/_build/${MIX_ENV}/rel/pinchflat ./
 
-HEALTHCHECK --interval=120s --start-period=10s \
+HEALTHCHECK --interval=30s --start-period=15s \
   CMD curl --fail http://localhost:${PORT}/healthcheck || exit 1
 
 # Start the app


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

- Updates the Docker healthcheck to run every 30s instead of every 2 minutes
  - Resolves #552 

## What's fixed?

N/A

## Any other comments?

N/A

