### PR TITLE
[Bugfix] Allow resetting rate limit sleep interval

### DIFF
--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -45,6 +45,6 @@ defmodule Pinchflat.Settings.Setting do
     setting
     |> cast(attrs, @allowed_fields)
     |> validate_required(@required_fields)
-    |> validate_number(:extractor_sleep_interval_seconds, greater_than: 0)
+    |> validate_number(:extractor_sleep_interval_seconds, greater_than_or_equal_to: 0)
   end
 end

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -85,5 +85,12 @@ defmodule Pinchflat.SettingsTest do
       assert %Ecto.Changeset{valid?: true} = Settings.change_setting(setting, %{extractor_sleep_interval_seconds: 0})
       assert %Ecto.Changeset{valid?: false} = Settings.change_setting(setting, %{extractor_sleep_interval_seconds: -1})
     end
+
+    test "allows you to reset the extractor sleep interval" do
+      setting = Settings.record()
+      assert {:ok, setting} = Settings.update_setting(setting, %{extractor_sleep_interval_seconds: 1})
+
+      assert %Ecto.Changeset{valid?: true} = Settings.change_setting(setting, %{extractor_sleep_interval_seconds: 0})
+    end
   end
 end


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Fixes bug where you couldn't reset the sleep interval to 0 for rate limiting
  - Resolves #569

## Any other comments?

N/A


