### PR TITLE
[Bugfix] Ensure a full indexing pass always runs if the source has never been indexed before

### DIFF
--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -231,8 +231,9 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   # The download archive isn't useful for playlists (since those are ordered arbitrarily)
   # and we don't want to use it if the indexing was forced by the user. In other words,
   # only create an archive for channels that are being indexed as part of their regular
-  # indexing schedule
+  # indexing schedule. The first indexing pass should also not create an archive.
   defp build_download_archive_options(%Source{collection_type: :playlist}, _was_forced), do: []
+  defp build_download_archive_options(%Source{last_indexed_at: nil}, _was_forced), do: []
   defp build_download_archive_options(_source, true), do: []
 
   defp build_download_archive_options(source, _was_forced) do


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Updates download archive logic to avoid creating an archive if the source has never been indexed
  - Resolves #573 

## Any other comments?

N/A
