### PR TITLE
[Enhancement] Auto-update yt-dlp

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,7 @@ import Config
 config :pinchflat,
   ecto_repos: [Pinchflat.Repo],
   generators: [timestamp_type: :utc_datetime],
+  env: config_env(),
   # Specifying backend data here makes mocking and local testing SUPER easy
   yt_dlp_executable: System.find_executable("yt-dlp"),
   apprise_executable: System.find_executable("apprise"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -49,16 +49,7 @@ config :pinchflat, PinchflatWeb.Endpoint,
 
 config :pinchflat, Oban,
   engine: Oban.Engines.Lite,
-  repo: Pinchflat.Repo,
-  # Keep old jobs for 30 days for display in the UI
-  plugins: [
-    {Oban.Plugins.Pruner, max_age: 30 * 24 * 60 * 60},
-    {Oban.Plugins.Cron,
-     crontab: [
-       {"0 1 * * *", Pinchflat.Downloading.MediaRetentionWorker},
-       {"0 2 * * *", Pinchflat.Downloading.MediaQualityUpgradeWorker}
-     ]}
-  ]
+  repo: Pinchflat.Repo
 
 # Configures the mailer
 #

--- a/lib/pinchflat/boot/post_boot_startup_tasks.ex
+++ b/lib/pinchflat/boot/post_boot_startup_tasks.ex
@@ -1,0 +1,46 @@
+defmodule Pinchflat.Boot.PostBootStartupTasks do
+  @moduledoc """
+  This module is responsible for running startup tasks on app boot
+  AFTER all other boot steps have taken place and the app is ready to serve requests.
+
+  It's a GenServer because that plays REALLY nicely with the existing
+  Phoenix supervision tree.
+  """
+
+  alias Pinchflat.YtDlp.UpdateWorker, as: YtDlpUpdateWorker
+
+  # restart: :temporary means that this process will never be restarted (ie: will run once and then die)
+  use GenServer, restart: :temporary
+  import Ecto.Query, warn: false
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, %{env: Application.get_env(:pinchflat, :env)}, opts)
+  end
+
+  @doc """
+  Runs post-boot application startup tasks.
+
+  Any code defined here will run every time the application starts. You must
+  make sure that the code is idempotent and safe to run multiple times.
+
+  This is a good place to set up default settings, create initial records, stuff like that.
+  Should be fast - anything with the potential to be slow should be kicked off as a job instead.
+  """
+  @impl true
+  def init(%{env: :test} = state) do
+    # Do nothing _as part of the app bootup process_.
+    # Since bootup calls `start_link` and that's where the `env` state is injected,
+    # you can still call `.init()` manually to run these tasks for testing purposes
+    {:ok, state}
+  end
+
+  def init(state) do
+    update_yt_dlp()
+
+    {:ok, state}
+  end
+
+  defp update_yt_dlp do
+    YtDlpUpdateWorker.kickoff()
+  end
+end

--- a/lib/pinchflat/boot/post_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/post_job_startup_tasks.ex
@@ -1,7 +1,7 @@
 defmodule Pinchflat.Boot.PostJobStartupTasks do
   @moduledoc """
   This module is responsible for running startup tasks on app boot
-  AFTER the job runner has initiallized.
+  AFTER the job runner has initialized.
 
   It's a GenServer because that plays REALLY nicely with the existing
   Phoenix supervision tree.
@@ -12,7 +12,7 @@ defmodule Pinchflat.Boot.PostJobStartupTasks do
   import Ecto.Query, warn: false
 
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, %{}, opts)
+    GenServer.start_link(__MODULE__, %{env: Application.get_env(:pinchflat, :env)}, opts)
   end
 
   @doc """
@@ -25,6 +25,13 @@ defmodule Pinchflat.Boot.PostJobStartupTasks do
   Should be fast - anything with the potential to be slow should be kicked off as a job instead.
   """
   @impl true
+  def init(%{env: :test} = state) do
+    # Do nothing _as part of the app bootup process_.
+    # Since bootup calls `start_link` and that's where the `env` state is injected,
+    # you can still call `.init()` manually to run these tasks for testing purposes
+    {:ok, state}
+  end
+
   def init(state) do
     # Nothing at the moment!
 

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -19,7 +19,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   alias Pinchflat.Lifecycle.UserScripts.CommandRunner, as: UserScriptRunner
 
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, %{}, opts)
+    GenServer.start_link(__MODULE__, %{env: Application.get_env(:pinchflat, :env)}, opts)
   end
 
   @doc """
@@ -32,6 +32,13 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   Should be fast - anything with the potential to be slow should be kicked off as a job instead.
   """
   @impl true
+  def init(%{env: :test} = state) do
+    # Do nothing _as part of the app bootup process_.
+    # Since bootup calls `start_link` and that's where the `env` state is injected,
+    # you can still call `.init()` manually to run these tasks for testing purposes
+    {:ok, state}
+  end
+
   def init(state) do
     ensure_tmpfile_directory()
     reset_executing_jobs()

--- a/lib/pinchflat/profiles/media_profile_deletion_worker.ex
+++ b/lib/pinchflat/profiles/media_profile_deletion_worker.ex
@@ -14,7 +14,7 @@ defmodule Pinchflat.Profiles.MediaProfileDeletionWorker do
   Starts the profile deletion worker. Does not attach it to a task like `kickoff_with_task/2`
   since deletion also cancels all tasks for the profile
 
-  Returns {:ok, %Task{}} | {:error, %Ecto.Changeset{}}
+  Returns {:ok, %Oban.Job{}} | {:error, %Ecto.Changeset{}}
   """
   def kickoff(profile, job_args \\ %{}, job_opts \\ []) do
     %{id: profile.id}

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -76,6 +76,24 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     end
   end
 
+  @doc """
+  Updates yt-dlp to the latest version
+
+  Returns {:ok, binary()} | {:error, binary()}
+  """
+  @impl YtDlpCommandRunner
+  def update do
+    command = backend_executable()
+
+    case CliUtils.wrap_cmd(command, ["--update"]) do
+      {output, 0} ->
+        {:ok, String.trim(output)}
+
+      {output, _} ->
+        {:error, output}
+    end
+  end
+
   defp generate_output_filepath(addl_opts) do
     case Keyword.get(addl_opts, :output_filepath) do
       nil -> FSUtils.generate_metadata_tmpfile(:json)

--- a/lib/pinchflat/yt_dlp/update_worker.ex
+++ b/lib/pinchflat/yt_dlp/update_worker.ex
@@ -7,12 +7,22 @@ defmodule Pinchflat.YtDlp.UpdateWorker do
 
   require Logger
 
+  alias __MODULE__
   alias Pinchflat.Settings
+
+  @doc """
+  Starts the yt-dlp update worker. Does not attach it to a task like `kickoff_with_task/2`
+
+  Returns {:ok, %Oban.Job{}} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff do
+    Oban.insert(UpdateWorker.new(%{}))
+  end
 
   @doc """
   Updates yt-dlp and saves the version to the settings.
 
-  This worker is scheduled to run via the Oban Cron plugin.
+  This worker is scheduled to run via the Oban Cron plugin as well as on app boot.
 
   Returns :ok
   """

--- a/lib/pinchflat/yt_dlp/update_worker.ex
+++ b/lib/pinchflat/yt_dlp/update_worker.ex
@@ -1,0 +1,34 @@
+defmodule Pinchflat.YtDlp.UpdateWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :local_data,
+    tags: ["local_data"]
+
+  require Logger
+
+  alias Pinchflat.Settings
+
+  @doc """
+  Updates yt-dlp and saves the version to the settings.
+
+  This worker is scheduled to run via the Oban Cron plugin.
+
+  Returns :ok
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    Logger.info("Updating yt-dlp")
+
+    yt_dlp_runner().update()
+
+    {:ok, yt_dlp_version} = yt_dlp_runner().version()
+    Settings.set(yt_dlp_version: yt_dlp_version)
+
+    :ok
+  end
+
+  defp yt_dlp_runner do
+    Application.get_env(:pinchflat, :yt_dlp_runner)
+  end
+end

--- a/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
+++ b/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
@@ -9,4 +9,5 @@ defmodule Pinchflat.YtDlp.YtDlpCommandRunner do
   @callback run(binary(), atom(), keyword(), binary()) :: {:ok, binary()} | {:error, binary(), integer()}
   @callback run(binary(), atom(), keyword(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
   @callback version() :: {:ok, binary()} | {:error, binary()}
+  @callback update() :: {:ok, binary()} | {:error, binary()}
 end

--- a/lib/pinchflat_web/endpoint.ex
+++ b/lib/pinchflat_web/endpoint.ex
@@ -20,7 +20,7 @@ defmodule PinchflatWeb.Endpoint do
   plug Plug.Static,
     at: "/",
     from: :pinchflat,
-    gzip: Mix.env() == :prod,
+    gzip: Application.compile_env(:pinchflat, :env) == :prod,
     only: PinchflatWeb.static_paths()
 
   # Code reloading can be explicitly enabled under the

--- a/test/pinchflat/boot/post_boot_startup_tasks_test.exs
+++ b/test/pinchflat/boot/post_boot_startup_tasks_test.exs
@@ -1,0 +1,26 @@
+defmodule Pinchflat.Boot.PostBootStartupTasksTest do
+  use Pinchflat.DataCase
+
+  # import Pinchflat.JobFixtures
+
+  # alias Pinchflat.Settings
+  alias Pinchflat.YtDlp.UpdateWorker
+  alias Pinchflat.Boot.PostBootStartupTasks
+
+  setup do
+    stub(YtDlpRunnerMock, :update, fn -> {:ok, "1"} end)
+    stub(YtDlpRunnerMock, :version, fn -> {:ok, "1"} end)
+
+    :ok
+  end
+
+  describe "update_yt_dlp" do
+    test "enqueues an update job" do
+      assert [] = all_enqueued(worker: UpdateWorker)
+
+      PostBootStartupTasks.init(%{})
+
+      assert [%Oban.Job{}] = all_enqueued(worker: UpdateWorker)
+    end
+  end
+end

--- a/test/pinchflat/boot/post_boot_startup_tasks_test.exs
+++ b/test/pinchflat/boot/post_boot_startup_tasks_test.exs
@@ -1,18 +1,8 @@
 defmodule Pinchflat.Boot.PostBootStartupTasksTest do
   use Pinchflat.DataCase
 
-  # import Pinchflat.JobFixtures
-
-  # alias Pinchflat.Settings
   alias Pinchflat.YtDlp.UpdateWorker
   alias Pinchflat.Boot.PostBootStartupTasks
-
-  setup do
-    stub(YtDlpRunnerMock, :update, fn -> {:ok, "1"} end)
-    stub(YtDlpRunnerMock, :version, fn -> {:ok, "1"} end)
-
-    :ok
-  end
 
   describe "update_yt_dlp" do
     test "enqueues an update job" do

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -154,6 +154,14 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     end
   end
 
+  describe "update/0" do
+    test "adds the update arg" do
+      assert {:ok, output} = Runner.update()
+
+      assert String.contains?(output, "--update")
+    end
+  end
+
   defp wrap_executable(new_executable, fun) do
     Application.put_env(:pinchflat, :yt_dlp_executable, new_executable)
     fun.()

--- a/test/pinchflat/yt_dlp/update_worker_test.exs
+++ b/test/pinchflat/yt_dlp/update_worker_test.exs
@@ -1,0 +1,24 @@
+defmodule Pinchflat.YtDlp.UpdateWorkerTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Settings
+  alias Pinchflat.YtDlp.UpdateWorker
+
+  describe "perform/1" do
+    test "calls the yt-dlp runner to update yt-dlp" do
+      expect(YtDlpRunnerMock, :update, fn -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+
+    test "saves the new version to the database" do
+      expect(YtDlpRunnerMock, :update, fn -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, "1.2.3"} end)
+
+      perform_job(UpdateWorker, %{})
+
+      assert {:ok, "1.2.3"} = Settings.get(:yt_dlp_version)
+    end
+  end
+end


### PR DESCRIPTION
## What's new?
- Automatically updates yt-dlp on app boot and once daily thereafter
  - Instead of a daily check at a set time, it schedules the update daily at the time of app boot. This ensures all instances don't hit the update at the same time and it buys me a little time if a yt-dlp update breaks things
  - I initially didn't add this since I wanted to be able to update and test any changes myself, but it's been almost a year and I've encountered _far_ more issues from delaying yt-dlp updates compared to an update causing compatibility issues

## What's changed?

N/A

## What's fixed?

N/A

## Any other comments?

N/A

