### PR TITLE
[Bugfix] Improve YouTube shorts detection for new YouTube pants

### DIFF
--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -151,7 +151,7 @@ defmodule Pinchflat.YtDlp.Media do
       #
       # These don't fail if duration or aspect_ratio are missing
       # due to Elixir's comparison semantics
-      response["duration"] <= 60 && response["aspect_ratio"] <= 0.85
+      response["duration"] <= 180 && response["aspect_ratio"] <= 0.85
     end
   end
 

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -269,7 +269,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
       response = %{
         "original_url" => "https://www.youtube.com/watch?v=TiZPUDkDYbk",
         "aspect_ratio" => 0.5,
-        "duration" => 59,
+        "duration" => 150,
         "upload_date" => "20210101"
       }
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

The title is a joke - don't yell at me

- Updates shorts detection logic to go from a cutoff of 60s to a cutoff of 180s to reflect the change in max shorts duration
  - Resolves #612 

## What's fixed?

N/A

## Any other comments?

N/A

