### PR TITLE
[Bugfix] Improve yt-dlp permissions to allow auto update

### DIFF
--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -118,7 +118,7 @@ WORKDIR "/app"
 
 # Set up data volumes
 RUN mkdir -p /config /downloads /etc/elixir_tzdata_data /etc/yt-dlp/plugins && \ 
-  chmod ugo+rw /etc/elixir_tzdata_data /etc/yt-dlp /etc/yt-dlp/plugins
+  chmod ugo+rw /etc/elixir_tzdata_data /etc/yt-dlp /etc/yt-dlp/plugins /usr/local/bin/yt-dlp
 
 # set runner ENV
 ENV MIX_ENV="prod"


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Updates permissions in the Dockerfile so that yt-dlp can self-update
  - Resolves #625 

## Any other comments?

N/A

