### PR TITLE
[Docs] Add podman to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ docker run \
   ghcr.io/kieraneglin/pinchflat:latest
 ```
 
+### Podman
+
+The Podman setup is similar to Docker but changes a few flags to run under a User Namespace instead of root. To run Pinchflat under Podman and use the current user's UID/GID for file access run this:
+
+```
+podman run \ 
+  --security-opt label=disable \
+  --userns=keep-id --user=$UID \
+  -e TZ=America/Los_Angeles \
+  -p 8945:8945 \
+  -v /host/path/to/config:/config:rw \
+  -v /host/path/to/downloads/:/downloads:rw \
+  ghcr.io/kieraneglin/pinchflat:latest
+```
+
+Using this setup consider creating a new `pinchflat` user and giving that user ownership to the config and download directory. See [Podman --userns](https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html) docs.
+
 ### IMPORTANT: File permissions
 
 You _must_ ensure the host directories you've mounted are writable by the user running the Docker container. If you get a permission error follow the steps it suggests. See [#106](https://github.com/kieraneglin/pinchflat/issues/106) for more.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ docker run \
 The Podman setup is similar to Docker but changes a few flags to run under a User Namespace instead of root. To run Pinchflat under Podman and use the current user's UID/GID for file access run this:
 
 ```
-podman run \ 
+podman run \
   --security-opt label=disable \
   --userns=keep-id --user=$UID \
   -e TZ=America/Los_Angeles \


### PR DESCRIPTION

## What's new?

Readme guide: Docker always has a tendency to get in my way on Debian. Also, I really like the userns setup for podman for giving permissions between host and container.

## What's changed?

Add README info for Podman


## Any other comments?

No worries if you don't want to take the PR. Just thought it could help some folks.

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
