### PR TITLE
[Bugfix] Fix header link when using `BASE_ROUTE_PATH`

### DIFF
--- a/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
+++ b/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
@@ -8,7 +8,7 @@
 >
   <section>
     <div class="flex items-center justify-between gap-2 px-6 py-4">
-      <a href="/" class="flex items-center">
+      <a href={~p"/"} class="flex items-center">
         <img src={~p"/images/logo-2024-03-20.png"} alt="Pinchflat" class="w-auto" />
       </a>
 


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

- Uses p-sigil for header homepage link so `BASE_ROUTE_PATH` is respected
  - Resolves #688

## Any other comments?

N/A

