### PR TITLE
fix: download correct yt-dlp for arm64 release build

### DIFF
--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -73,6 +73,7 @@ RUN mix release
 
 FROM ${RUNNER_IMAGE}
 
+ARG TARGETPLATFORM
 ARG PORT=8945
 
 COPY --from=builder ./usr/local/bin/ffmpeg /usr/bin/ffmpeg


### PR DESCRIPTION
## What's new?

N/A

## What's changed?

N/A

## What's fixed?

`TARGETPLATFORM` is not set in runner image stage and falls back to `linux/amd64` when downloading `yt-dlp` release binary.

## Any other comments?

N/A

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
