### PR TITLE
Enable overflow scroll for tables inside tabs

### DIFF
--- a/lib/pinchflat_web/components/custom_components/tab_components.ex
+++ b/lib/pinchflat_web/components/custom_components/tab_components.ex
@@ -41,7 +41,7 @@ defmodule PinchflatWeb.CustomComponents.TabComponents do
           {render_slot(@tab_append)}
         </div>
       </header>
-      <div class="mt-4 min-h-60">
+      <div class="mt-4 min-h-60 overflow-x-auto">
         <div :for={tab <- @tab} x-show={"openTab === '#{tab.id}'"} class="font-medium leading-relaxed">
           {render_slot(tab)}
         </div>

--- a/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
@@ -23,7 +23,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
       <header class="flex justify-between items-center mb-4">
         <span class="flex items-center">
           <.icon_button icon_name="hero-arrow-path" class="h-10 w-10" phx-click="reload_page" tooltip="Refresh" />
-          <span class="ml-2">
+          <span class="mx-2">
             Showing <.localized_number number={length(@records)} /> of <.localized_number number={@filtered_record_count} />
           </span>
         </span>


### PR DESCRIPTION
## What's fixed?

On the sources and media profiles screens it wasn't possible to scroll L to R on the tables on mobile

https://github.com/user-attachments/assets/152a473f-db7b-4a18-99c2-89e5073110b0


This is now fixed

https://github.com/user-attachments/assets/b7613d5f-00a9-4da5-a5bd-db90c5dcd064




## Any other comments?

Thanks for the awesome app!

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
