### PR TITLE
Move Active Tasks to tab in Media History section

### DIFF
--- a/lib/pinchflat_web/controllers/pages/page_html/home.html.heex
+++ b/lib/pinchflat_web/controllers/pages/page_html/home.html.heex
@@ -56,12 +56,8 @@
         session: %{"media_state" => "pending"}
       )}
     </:tab>
+    <:tab title="Active Tasks" id="active-tasks">
+      {live_render(@conn, Pinchflat.Pages.JobTableLive)}
+    </:tab>
   </.tabbed_layout>
-</div>
-
-<div class="rounded-sm border shadow-default border-strokedark bg-boxdark mt-4 p-5">
-  <span class="text-2xl font-medium mb-4">Active Tasks</span>
-  <section class="mt-6 min-h-80">
-    {live_render(@conn, Pinchflat.Pages.JobTableLive)}
-  </section>
 </div>


### PR DESCRIPTION
## What's new?

Consolidate the home page UI by moving Active Tasks from a separate section into a third tab alongside Downloaded and Pending tabs.

## What's changed?

Active Tasks is more visible. User is not required to scroll down.

## What's fixed?

N/A

## Any other comments?

N/A

- [ ✅] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
