### PR TITLE
Define static_season__episode_by_index_reversed episode template name option

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -6,8 +6,10 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   alias Pinchflat.Sources
   alias Pinchflat.Sources.Source
   alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Media.MediaQuery
   alias Pinchflat.Downloading.OutputPathBuilder
   alias Pinchflat.Downloading.QualityOptionBuilder
+  alias Pinchflat.Repo
 
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
 
@@ -209,8 +211,26 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
       "source_collection_name" => source.collection_name,
       "source_collection_type" => to_string(source.collection_type),
       "media_playlist_index" => pad_int(media_item_with_preloads.playlist_index),
+      "media_playlist_index_reversed" => pad_int(calculate_reversed_playlist_index(media_item_with_preloads)),
       "media_upload_date_index" => pad_int(media_item_with_preloads.upload_date_index)
     }
+  end
+
+  defp calculate_reversed_playlist_index(media_item_with_preloads) do
+    source = media_item_with_preloads.source
+    current_index = media_item_with_preloads.playlist_index || 0
+
+    max_index =
+      MediaQuery.new()
+      |> where(^MediaQuery.for_source(source))
+      |> Repo.aggregate(:max, :playlist_index)
+
+    case {max_index, current_index} do
+      {nil, _} -> 0
+      {max, _} when max <= 0 -> 0
+      {max, current} when current > 0 -> max - current + 1
+      _ -> 0
+    end
   end
 
   # I don't love the string manipulation here, but what can ya' do.

--- a/lib/pinchflat/downloading/output_path_builder.ex
+++ b/lib/pinchflat/downloading/output_path_builder.ex
@@ -56,6 +56,7 @@ defmodule Pinchflat.Downloading.OutputPathBuilder do
       "season_episode_index_from_date" => "s%(upload_date>%Y)Se%(upload_date>%m%d)S{{ media_upload_date_index }}",
       "artist_name" => "%(artist,creator,uploader,uploader_id)S",
       "static_season__episode_by_index" => "Season 1/s01e{{ media_playlist_index }}",
+      "static_season__episode_by_index_reversed" => "Season 1/s01e{{ media_playlist_index_reversed }}",
       "static_season__episode_by_date" => "Season 1/s01e%(upload_date>%y%m%d)S",
       "season_by_year__episode_by_date" => "Season %(upload_date>%Y)S/s%(upload_date>%Y)Se%(upload_date>%m%d)S",
       "season_by_year__episode_by_date_and_index" =>

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -63,6 +63,8 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
         "same as the above but it handles dates better. <strong>This is the recommended option</strong>",
       static_season__episode_by_index:
         "<code>Season 1/s01eXX</code> where <code>XX</code> is the video's position in the playlist. Only recommended for playlists (not channels) that don't change",
+      static_season__episode_by_index_reversed:
+        "<code>Season 1/s01eXX</code> where <code>XX</code> is the video's position in the playlist in reversed order (last video is episode 1).",
       static_season__episode_by_date:
         "<code>Season 1/s01eYYMMDD</code>. Recommended for playlists that might change or where order isn't important"
     ]
@@ -86,6 +88,8 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
         "the upload date formatted as <code>sYYYYeMMDDII</code> where <code>II</code> is an index to prevent date collisions",
       media_playlist_index:
         "the place of the media item in the playlist. Do not use with channels. May not work if the playlist is updated",
+      media_playlist_index_reversed:
+        "the place of the media item in the playlist in reversed order (last video is 1). Do not use with channels. May not work if the playlist is updated",
       media_item_id: "the ID of the media item in Pinchflat's database",
       source_id: "the ID of the source in Pinchflat's database",
       media_profile_id: "the ID of the media profile in Pinchflat's database"


### PR DESCRIPTION
## What's new?

A new `static_season__episode_by_index_reversed template` name option

### Why?

There are sources I want to add that don't publish playlists for their shows. For example [Bigtop Burger](https://www.youtube.com/@Worthikids/videos) is published without a playlist. My strategy for these shows is:
- Add the channel as a source
- Use regex filtering to extract only the episodes of the show
- Order by index, with the oldest episode being `1` and the newest episode being `n`. This is the key logic missing from Pinchflat right now to support this

My goal at this point is to ask the maintainers: would you be open to merging this functionality? The name in this draft is clunky and could be improved, but I think the logic would be beneficial.

For transparency: I used cursor to build this, as I have not worked with Elixir before. Happy to refine this PR & add tests, I don't want to contribute low quality code to the project.

## What's changed?

No existing logic changed.

## What's fixed?

No bug fixes.

## Any other comments?

N/A

- [x] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers

