### PR TITLE
Removed the version from the docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Simply search for Pinchflat in the Community Apps store!
 Docker Compose file:
 
 ```yaml
-version: '3'
 services:
   pinchflat:
     image: ghcr.io/kieraneglin/pinchflat:latest


### PR DESCRIPTION
Removed the version from the docker compose, otherwise Docker compose gives a warning that its not needed.

Merry Christmas

## What's new?

Documentation update

## What's changed?

Removed the version field from the docker compose example. Otherwise docker compose complains with: 

WARN[0000] /opt/pinchflat/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 


## What's fixed?

Minor line fix

## Any other comments?

Merry chrismas

- [ X] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
