### PR TITLE
Add Oban Lifeline plugin to rescue orphaned jobs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -61,6 +61,8 @@ config :pinchflat, Oban,
   plugins: [
     # Keep old jobs for 30 days for display in the UI
     {Oban.Plugins.Pruner, max_age: 30 * 24 * 60 * 60},
+    # Rescue orphaned jobs stuck in "executing" state after crash/restart
+    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
     {Oban.Plugins.Cron,
      crontab: [
        {"#{current_minute} #{current_hour} * * *", Pinchflat.YtDlp.UpdateWorker},


### PR DESCRIPTION
## What's new?

Jobs stuck in "executing" state for more than 30 minutes (e.g. after a container restart) will automatically be rescued and retried.

## What's changed?

N/A

## What's fixed?

Jobs stuck in "executing" state for more than 30 minutes (e.g. after a container restart) will automatically be rescued and retried.

## Any other comments?

Implemented with the help of claude code

- [X] I am the original author of this code and I am giving it freely to the community and Pinchflat project maintainers
